### PR TITLE
Zero cost futures via associated type

### DIFF
--- a/examples/http.rs
+++ b/examples/http.rs
@@ -5,7 +5,6 @@ extern crate web3;
 
 use std::thread;
 use futures::Future;
-use web3::api::Eth;
 
 fn main() {
   let mut event_loop = tokio_core::reactor::Core::new().unwrap();

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -2,7 +2,6 @@ extern crate futures;
 extern crate web3;
 
 use futures::Future;
-use web3::api::Eth;
 
 fn main() {
   let web3 = web3::Web3::new(web3::transports::Http::new("http://localhost:8545").unwrap());

--- a/src/api/eth.rs
+++ b/src/api/eth.rs
@@ -1,7 +1,5 @@
 //! `Eth` namespace
 
-use futures::Future;
-
 use api::Namespace;
 use helpers::{self, CallResult};
 use types::{
@@ -10,7 +8,7 @@ use types::{
   Transaction, TransactionId, TransactionReceipt, TransactionRequest,
   U256, Work,
 };
-use {Result, Transport};
+use {Transport};
 
 /// List of methods from `eth` namespace
 pub trait Eth<T: Transport> {

--- a/src/api/eth.rs
+++ b/src/api/eth.rs
@@ -10,173 +10,84 @@ use types::{
 };
 use {Transport};
 
-/// List of methods from `eth` namespace
-pub trait Eth<T: Transport> {
-  /// Get list of available accounts.
-  fn accounts(&self) -> CallResult<Vec<Address>, T::Out>;
-
-  /// Get current block number
-  fn block_number(&self) -> CallResult<U256, T::Out>;
-
-  /// Call a constant method of contract without changing the state of the blockchain.
-  fn call(&self, options: CallRequest, block: Option<BlockNumber>) -> CallResult<Bytes, T::Out>;
-
-  /// Get coinbase address
-  fn coinbase(&self) -> CallResult<Address, T::Out>;
-
-  /// Compile LLL
-  fn compile_lll(&self, String) -> CallResult<Bytes, T::Out>;
-
-  /// Compile Solidity
-  fn compile_solidity(&self, String) -> CallResult<Bytes, T::Out>;
-
-  /// Compile Serpent
-  fn compile_serpent(&self, String) -> CallResult<Bytes, T::Out>;
-
-  /// Call a contract without changing the state of the blockchain to estimate gas usage.
-  fn estimate_gas(&self, options: CallRequest, block: Option<BlockNumber>) -> CallResult<U256, T::Out>;
-
-  /// Get current recommended gas price
-  fn gas_price(&self) -> CallResult<U256, T::Out>;
-
-  /// Get balance of given address
-  fn balance(&self, address: Address, block: Option<BlockNumber>) -> CallResult<U256, T::Out>;
-
-  /// Get block details
-  fn block(&self, block: BlockId, include_txs: bool) -> CallResult<Block, T::Out>;
-
-  /// Get number of transactions in block
-  fn block_transaction_count(&self, block: BlockId) -> CallResult<Option<U256>, T::Out>;
-
-  /// Get code under given address
-  fn code(&self, address: Address, block: Option<BlockNumber>) -> CallResult<Bytes, T::Out>;
-
-  /// Get supported compilers
-  fn compilers(&self) -> CallResult<Vec<String>, T::Out>;
-
-  /// Get storage entry
-  fn storage(&self, address: Address, idx: U256, block: Option<BlockNumber>) -> CallResult<H256, T::Out>;
-
-  /// Get nonce
-  fn transaction_count(&self, address: Address, block: Option<BlockNumber>) -> CallResult<U256, T::Out>;
-
-  /// Get transaction
-  fn transaction(&self, id: TransactionId) -> CallResult<Option<Transaction>, T::Out>;
-
-  /// Get transaction receipt
-  fn transaction_receipt(&self, hash: H256) -> CallResult<Option<TransactionReceipt>, T::Out>;
-
-  /// Get uncle
-  fn uncle(&self, block: BlockId, index: Index) -> CallResult<Option<Block>, T::Out>;
-
-  /// Get uncle count in block
-  fn uncle_count(&self, block: BlockId) -> CallResult<Option<U256>, T::Out>;
-
-  /// Get work package
-  fn work(&self) -> CallResult<Work, T::Out>;
-
-  /// Get hash rate
-  fn hashrate(&self) -> CallResult<U256, T::Out>;
-
-  /// Get mining status
-  fn mining(&self) -> CallResult<bool, T::Out>;
-
-  /// Start new block filter
-  fn new_block_filter(&self) -> CallResult<U256, T::Out>;
-
-  /// Start new pending transaction filter
-  fn new_pending_transaction_filter(&self) -> CallResult<U256, T::Out>;
-
-  /// Start new pending transaction filter
-  fn protocol_version(&self) -> CallResult<String, T::Out>;
-
-  /// Sends a rlp-encoded signed transaction
-  fn send_raw_transaction(&self, rlp: Bytes) -> CallResult<H256, T::Out>;
-
-  /// Sends a transaction transaction
-  fn send_transaction(&self, tx: TransactionRequest) -> CallResult<H256, T::Out>;
-
-  /// Signs a hash of given data
-  fn sign(&self, address: Address, data: Bytes) -> CallResult<H512, T::Out>;
-
-  /// Submit hashrate of external miner
-  fn submit_hashrate(&self, rate: U256, id: H256) -> CallResult<bool, T::Out>;
-
-  /// Submit work of external miner
-  fn submit_work(&self, nonce: H64, pow_hash: H256, mix_hash: H256) -> CallResult<bool, T::Out>;
-
-  // TODO [ToDr] Proper type?
-  /// Get syncing status
-  fn syncing(&self) -> CallResult<bool, T::Out>;
-}
-
 /// `Eth` namespace
-pub struct EthApi<'a, T: 'a> {
+pub struct Eth<'a, T: 'a> {
   transport: &'a T,
 }
 
-impl<'a, T: Transport + 'a> Namespace<'a, T> for EthApi<'a, T> {
+impl<'a, T: Transport + 'a> Namespace<'a, T> for Eth<'a, T> {
   fn new(transport: &'a T) -> Self where Self: Sized {
-    EthApi {
+    Eth {
       transport: transport,
     }
   }
 }
 
-impl<'a, T: Transport + 'a> Eth<T> for EthApi<'a, T> {
-  fn accounts(&self) -> CallResult<Vec<Address>, T::Out> {
+impl<'a, T: Transport + 'a> Eth<'a, T> {
+  /// Get list of available accounts.
+  pub fn accounts(&self) -> CallResult<Vec<Address>, T::Out> {
     CallResult::new(self.transport.execute("eth_accounts", vec![]))
   }
 
-  fn block_number(&self) -> CallResult<U256, T::Out> {
+  /// Get current block number
+  pub fn block_number(&self) -> CallResult<U256, T::Out> {
     CallResult::new(self.transport.execute("eth_blockNumber", vec![]))
   }
 
-  fn call(&self, req: CallRequest, block: Option<BlockNumber>) -> CallResult<Bytes, T::Out> {
+  /// Call a constant method of contract without changing the state of the blockchain.
+  pub fn call(&self, req: CallRequest, block: Option<BlockNumber>) -> CallResult<Bytes, T::Out> {
     let req = helpers::serialize(&req);
     let block = helpers::serialize(&block.unwrap_or(BlockNumber::Latest));
 
     CallResult::new(self.transport.execute("eth_call", vec![req, block]))
   }
 
-  fn coinbase(&self) -> CallResult<Address, T::Out> {
+  /// Get coinbase address
+  pub fn coinbase(&self) -> CallResult<Address, T::Out> {
     CallResult::new(self.transport.execute("eth_coinbase", vec![]))
   }
 
-  fn compile_lll(&self, code: String) -> CallResult<Bytes, T::Out> {
+  /// Compile LLL
+  pub fn compile_lll(&self, code: String) -> CallResult<Bytes, T::Out> {
     let code = helpers::serialize(&code);
     CallResult::new(self.transport.execute("eth_compileLLL", vec![code]))
   }
 
-  fn compile_solidity(&self, code: String) -> CallResult<Bytes, T::Out> {
+  /// Compile Solidity
+  pub fn compile_solidity(&self, code: String) -> CallResult<Bytes, T::Out> {
     let code = helpers::serialize(&code);
     CallResult::new(self.transport.execute("eth_compileSolidity", vec![code]))
   }
 
-  fn compile_serpent(&self, code: String) -> CallResult<Bytes, T::Out> {
+  /// Compile Serpent
+  pub fn compile_serpent(&self, code: String) -> CallResult<Bytes, T::Out> {
     let code = helpers::serialize(&code);
     CallResult::new(self.transport.execute("eth_compileSerpent", vec![code]))
   }
 
-  fn estimate_gas(&self, req: CallRequest, block: Option<BlockNumber>) -> CallResult<U256, T::Out> {
+  /// Call a contract without changing the state of the blockchain to estimate gas usage.
+  pub fn estimate_gas(&self, req: CallRequest, block: Option<BlockNumber>) -> CallResult<U256, T::Out> {
     let req = helpers::serialize(&req);
     let block = helpers::serialize(&block.unwrap_or(BlockNumber::Latest));
 
     CallResult::new(self.transport.execute("eth_estimateGas", vec![req, block]))
   }
 
-  fn gas_price(&self) -> CallResult<U256, T::Out> {
+  /// Get current recommended gas price
+  pub fn gas_price(&self) -> CallResult<U256, T::Out> {
     CallResult::new(self.transport.execute("eth_gasPrice", vec![]))
   }
 
-  fn balance(&self, address: Address, block: Option<BlockNumber>) -> CallResult<U256, T::Out> {
+  /// Get balance of given address
+  pub fn balance(&self, address: Address, block: Option<BlockNumber>) -> CallResult<U256, T::Out> {
     let address = helpers::serialize(&address);
     let block = helpers::serialize(&block.unwrap_or(BlockNumber::Latest));
 
     CallResult::new(self.transport.execute("eth_getBalance", vec![address, block]))
   }
 
-  fn block(&self, block: BlockId, include_txs: bool) -> CallResult<Block, T::Out> {
+  /// Get block details
+  pub fn block(&self, block: BlockId, include_txs: bool) -> CallResult<Block, T::Out> {
     let include_txs = helpers::serialize(&include_txs);
 
     let result = match block {
@@ -193,7 +104,8 @@ impl<'a, T: Transport + 'a> Eth<T> for EthApi<'a, T> {
     CallResult::new(result)
   }
 
-  fn block_transaction_count(&self, block: BlockId) -> CallResult<Option<U256>, T::Out> {
+  /// Get number of transactions in block
+  pub fn block_transaction_count(&self, block: BlockId) -> CallResult<Option<U256>, T::Out> {
     let result = match block {
       BlockId::Hash(hash) => {
         let hash = helpers::serialize(&hash);
@@ -208,18 +120,21 @@ impl<'a, T: Transport + 'a> Eth<T> for EthApi<'a, T> {
     CallResult::new(result)
   }
 
-  fn code(&self, address: Address, block: Option<BlockNumber>) -> CallResult<Bytes, T::Out> {
+  /// Get code under given address
+  pub fn code(&self, address: Address, block: Option<BlockNumber>) -> CallResult<Bytes, T::Out> {
     let address = helpers::serialize(&address);
     let block = helpers::serialize(&block.unwrap_or(BlockNumber::Latest));
 
     CallResult::new(self.transport.execute("eth_getCode", vec![address, block]))
   }
 
-  fn compilers(&self) -> CallResult<Vec<String>, T::Out> {
+  /// Get supported compilers
+  pub fn compilers(&self) -> CallResult<Vec<String>, T::Out> {
     CallResult::new(self.transport.execute("eth_getCompilers", vec![]))
   }
 
-  fn storage(&self, address: Address, idx: U256, block: Option<BlockNumber>) -> CallResult<H256, T::Out> {
+  /// Get storage entry
+  pub fn storage(&self, address: Address, idx: U256, block: Option<BlockNumber>) -> CallResult<H256, T::Out> {
     let address = helpers::serialize(&address);
     let idx = helpers::serialize(&idx);
     let block = helpers::serialize(&block.unwrap_or(BlockNumber::Latest));
@@ -227,14 +142,16 @@ impl<'a, T: Transport + 'a> Eth<T> for EthApi<'a, T> {
     CallResult::new(self.transport.execute("eth_getStorageAt", vec![address, idx, block]))
   }
 
-  fn transaction_count(&self, address: Address, block: Option<BlockNumber>) -> CallResult<U256, T::Out> {
+  /// Get nonce
+  pub fn transaction_count(&self, address: Address, block: Option<BlockNumber>) -> CallResult<U256, T::Out> {
     let address = helpers::serialize(&address);
     let block = helpers::serialize(&block.unwrap_or(BlockNumber::Latest));
 
    CallResult::new(self.transport.execute("eth_getTransactionCount", vec![address, block]))
   }
 
-  fn transaction(&self, id: TransactionId) -> CallResult<Option<Transaction>, T::Out> {
+  /// Get transaction
+  pub fn transaction(&self, id: TransactionId) -> CallResult<Option<Transaction>, T::Out> {
     let result = match id {
       TransactionId::Hash(hash) => {
         let hash = helpers::serialize(&hash);
@@ -255,13 +172,15 @@ impl<'a, T: Transport + 'a> Eth<T> for EthApi<'a, T> {
     CallResult::new(result)
   }
 
-  fn transaction_receipt(&self, hash: H256) -> CallResult<Option<TransactionReceipt>, T::Out> {
+  /// Get transaction receipt
+  pub fn transaction_receipt(&self, hash: H256) -> CallResult<Option<TransactionReceipt>, T::Out> {
     let hash = helpers::serialize(&hash);
 
     CallResult::new(self.transport.execute("eth_getTransactionReceipt", vec![hash]))
   }
 
-  fn uncle(&self, block: BlockId, index: Index) -> CallResult<Option<Block>, T::Out> {
+  /// Get uncle
+  pub fn uncle(&self, block: BlockId, index: Index) -> CallResult<Option<Block>, T::Out> {
     let index = helpers::serialize(&index);
 
     let result = match block {
@@ -278,7 +197,8 @@ impl<'a, T: Transport + 'a> Eth<T> for EthApi<'a, T> {
     CallResult::new(result)
   }
 
-  fn uncle_count(&self, block: BlockId) -> CallResult<Option<U256>, T::Out> {
+  /// Get uncle count in block
+  pub fn uncle_count(&self, block: BlockId) -> CallResult<Option<U256>, T::Out> {
     let result = match block {
       BlockId::Hash(hash) => {
         let hash = helpers::serialize(&hash);
@@ -293,60 +213,73 @@ impl<'a, T: Transport + 'a> Eth<T> for EthApi<'a, T> {
     CallResult::new(result)
   }
 
-  fn work(&self) -> CallResult<Work, T::Out> {
+  /// Get work package
+  pub fn work(&self) -> CallResult<Work, T::Out> {
     CallResult::new(self.transport.execute("eth_getWork", vec![]))
   }
 
-  fn hashrate(&self) -> CallResult<U256, T::Out> {
+  /// Get hash rate
+  pub fn hashrate(&self) -> CallResult<U256, T::Out> {
     CallResult::new(self.transport.execute("eth_hashrate", vec![]))
   }
 
-  fn mining(&self) -> CallResult<bool, T::Out> {
+  /// Get mining status
+  pub fn mining(&self) -> CallResult<bool, T::Out> {
     CallResult::new(self.transport.execute("eth_mining", vec![]))
   }
 
-  fn new_block_filter(&self) -> CallResult<U256, T::Out> {
+  /// Start new block filter
+  pub fn new_block_filter(&self) -> CallResult<U256, T::Out> {
     CallResult::new(self.transport.execute("eth_newBlockFilter", vec![]))
   }
 
-  fn new_pending_transaction_filter(&self) -> CallResult<U256, T::Out> {
+  /// Start new pending transaction filter
+  pub fn new_pending_transaction_filter(&self) -> CallResult<U256, T::Out> {
     CallResult::new(self.transport.execute("eth_newPendingTransactionFilter", vec![]))
   }
 
-  fn protocol_version(&self) -> CallResult<String, T::Out> {
+  /// Start new pending transaction filter
+  pub fn protocol_version(&self) -> CallResult<String, T::Out> {
     CallResult::new(self.transport.execute("eth_protocolVersion", vec![]))
   }
 
-  fn send_raw_transaction(&self, rlp: Bytes) -> CallResult<H256, T::Out> {
+  /// Sends a rlp-encoded signed transaction
+  pub fn send_raw_transaction(&self, rlp: Bytes) -> CallResult<H256, T::Out> {
     let rlp = helpers::serialize(&rlp);
     CallResult::new(self.transport.execute("eth_sendRawTransaction", vec![rlp]))
   }
 
-  fn send_transaction(&self, tx: TransactionRequest) -> CallResult<H256, T::Out> {
+  /// Sends a transaction transaction
+  pub fn send_transaction(&self, tx: TransactionRequest) -> CallResult<H256, T::Out> {
     let tx = helpers::serialize(&tx);
     CallResult::new(self.transport.execute("eth_sendTransaction", vec![tx]))
   }
 
-  fn sign(&self, address: Address, data: Bytes) -> CallResult<H512, T::Out> {
+  /// Signs a hash of given data
+  pub fn sign(&self, address: Address, data: Bytes) -> CallResult<H512, T::Out> {
     let address = helpers::serialize(&address);
     let data = helpers::serialize(&data);
     CallResult::new(self.transport.execute("eth_sign", vec![address, data]))
   }
 
-  fn submit_hashrate(&self, rate: U256, id: H256) -> CallResult<bool, T::Out> {
+  /// Submit hashrate of external miner
+  pub fn submit_hashrate(&self, rate: U256, id: H256) -> CallResult<bool, T::Out> {
     let rate = helpers::serialize(&rate);
     let id = helpers::serialize(&id);
     CallResult::new(self.transport.execute("eth_submitHashrate", vec![rate, id]))
   }
 
-  fn submit_work(&self, nonce: H64, pow_hash: H256, mix_hash: H256) -> CallResult<bool, T::Out> {
+  /// Submit work of external miner
+  pub fn submit_work(&self, nonce: H64, pow_hash: H256, mix_hash: H256) -> CallResult<bool, T::Out> {
     let nonce = helpers::serialize(&nonce);
     let pow_hash = helpers::serialize(&pow_hash);
     let mix_hash = helpers::serialize(&mix_hash);
     CallResult::new(self.transport.execute("eth_submitWork", vec![nonce, pow_hash, mix_hash]))
   }
 
-  fn syncing(&self) -> CallResult<bool, T::Out> {
+  // TODO [ToDr] Proper type?
+  /// Get syncing status
+  pub fn syncing(&self) -> CallResult<bool, T::Out> {
     CallResult::new(self.transport.execute("eth_syncing", vec![]))
   }
 }
@@ -363,20 +296,20 @@ mod tests {
   };
   use rpc::Value;
 
-  use super::{Eth, EthApi};
+  use super::Eth;
 
   rpc_test! (
-    EthApi:accounts => "eth_accounts";
+    Eth:accounts => "eth_accounts";
     Value::Array(vec![Value::String("0x123".into())]) => vec!["0x123".into()]
   );
 
   rpc_test! (
-    EthApi:block_number => "eth_blockNumber";
+    Eth:block_number => "eth_blockNumber";
     Value::String("0x123".into()) => "0x123"
   );
 
   rpc_test! (
-    EthApi:call, CallRequest {
+    Eth:call, CallRequest {
       from: None, to: "0x123".into(),
       gas: None, gas_price: None,
       value: Some("0x1".into()), data: None,
@@ -387,27 +320,27 @@ mod tests {
   );
 
   rpc_test! (
-    EthApi:coinbase => "eth_coinbase";
+    Eth:coinbase => "eth_coinbase";
     Value::String("0x123".into()) => "0x123"
   );
 
   rpc_test! (
-    EthApi:compile_lll, "code" => "eth_compileLLL", vec![r#""code""#];
+    Eth:compile_lll, "code" => "eth_compileLLL", vec![r#""code""#];
     Value::String("0x0123".into()) => Bytes(vec![0x1, 0x23])
   );
 
   rpc_test! (
-    EthApi:compile_solidity, "code" => "eth_compileSolidity", vec![r#""code""#];
+    Eth:compile_solidity, "code" => "eth_compileSolidity", vec![r#""code""#];
     Value::String("0x0123".into()) => Bytes(vec![0x1, 0x23])
   );
 
   rpc_test! (
-    EthApi:compile_serpent, "code" => "eth_compileSerpent", vec![r#""code""#];
+    Eth:compile_serpent, "code" => "eth_compileSerpent", vec![r#""code""#];
     Value::String("0x0123".into()) => Bytes(vec![0x1, 0x23])
   );
 
   rpc_test! (
-    EthApi:estimate_gas, CallRequest {
+    Eth:estimate_gas, CallRequest {
       from: None, to: "0x123".into(),
       gas: None, gas_price: None,
       value: Some("0x1".into()), data: None,
@@ -418,80 +351,80 @@ mod tests {
   );
 
   rpc_test! (
-    EthApi:gas_price => "eth_gasPrice";
+    Eth:gas_price => "eth_gasPrice";
     Value::String("0x123".into()) => "0x123"
   );
 
   rpc_test! (
-    EthApi:balance, "0x123", None
+    Eth:balance, "0x123", None
     =>
     "eth_getBalance", vec![r#""0x123""#, r#""latest""#];
     Value::String("0x123".into()) => "0x123"
   );
 
   rpc_test! (
-    EthApi:block:block_by_hash, BlockId::Hash("0x123".into()), true
+    Eth:block:block_by_hash, BlockId::Hash("0x123".into()), true
     =>
     "eth_getBlockByHash", vec![r#""0x123""#, r#"true"#];
     Value::Null => ()
   );
 
   rpc_test! (
-    EthApi:block, BlockNumber::Pending, true
+    Eth:block, BlockNumber::Pending, true
     =>
     "eth_getBlockByNumber", vec![r#""pending""#, r#"true"#];
     Value::Null => ()
   );
 
   rpc_test! (
-    EthApi:block_transaction_count:block_tx_count_by_hash, "0x123".to_owned()
+    Eth:block_transaction_count:block_tx_count_by_hash, "0x123".to_owned()
     =>
     "eth_getBlockTransactionCountByHash", vec![r#""0x123""#];
     Value::String("0x123".into()) => Some("0x123".into())
   );
 
   rpc_test! (
-    EthApi:block_transaction_count, BlockNumber::Pending
+    Eth:block_transaction_count, BlockNumber::Pending
     =>
     "eth_getBlockTransactionCountByNumber", vec![r#""pending""#];
     Value::Null => None
   );
 
   rpc_test! (
-    EthApi:code, "0x123", Some(BlockNumber::Pending)
+    Eth:code, "0x123", Some(BlockNumber::Pending)
     =>
     "eth_getCode", vec![r#""0x123""#, r#""pending""#];
     Value::String("0x0123".into()) => Bytes(vec![0x1, 0x23])
   );
 
   rpc_test! (
-    EthApi:compilers => "eth_getCompilers";
+    Eth:compilers => "eth_getCompilers";
     Value::Array(vec![]) => vec![]
   );
 
   rpc_test! (
-    EthApi:storage, "0x123", "0x456", None
+    Eth:storage, "0x123", "0x456", None
     =>
     "eth_getStorageAt", vec![r#""0x123""#, r#""0x456""#, r#""latest""#];
     Value::String("0x123".into()) => "0x123"
   );
 
   rpc_test! (
-    EthApi:transaction_count, "0x123", None
+    Eth:transaction_count, "0x123", None
     =>
     "eth_getTransactionCount", vec![r#""0x123""#, r#""latest""#];
     Value::String("0x123".into()) => "0x123"
   );
 
   rpc_test! (
-    EthApi:transaction:tx_by_hash, TransactionId::Hash("0x123".into())
+    Eth:transaction:tx_by_hash, TransactionId::Hash("0x123".into())
     =>
     "eth_getTransactionByHash", vec![r#""0x123""#];
     Value::Array(vec![]) => Some(())
   );
 
   rpc_test! (
-    EthApi:transaction:tx_by_block_hash_and_index, TransactionId::Block(
+    Eth:transaction:tx_by_block_hash_and_index, TransactionId::Block(
       BlockId::Hash("0x123".into()),
       "0x5".into()
     )
@@ -501,7 +434,7 @@ mod tests {
   );
 
   rpc_test! (
-    EthApi:transaction:tx_by_block_no_and_index, TransactionId::Block(
+    Eth:transaction:tx_by_block_no_and_index, TransactionId::Block(
       BlockNumber::Pending.into(),
       "0x5".into()
     )
@@ -511,78 +444,78 @@ mod tests {
   );
 
   rpc_test! (
-    EthApi:transaction_receipt, "0x123".to_owned()
+    Eth:transaction_receipt, "0x123".to_owned()
     =>
     "eth_getTransactionReceipt", vec![r#""0x123""#];
     Value::Array(vec![]) => Some(())
   );
 
   rpc_test! (
-    EthApi:uncle:uncle_by_hash, BlockId::Hash("0x123".into()), "0x5"
+    Eth:uncle:uncle_by_hash, BlockId::Hash("0x123".into()), "0x5"
     =>
     "eth_getUncleByBlockHashAndIndex", vec![r#""0x123""#, r#""0x5""#];
     Value::Array(vec![]) => Some(())
   );
 
   rpc_test! (
-    EthApi:uncle:uncle_by_no, BlockNumber::Earliest, "0x5"
+    Eth:uncle:uncle_by_no, BlockNumber::Earliest, "0x5"
     =>
     "eth_getUncleByBlockNumberAndIndex", vec![r#""earliest""#, r#""0x5""#];
     Value::Array(vec![]) => Some(())
   );
 
   rpc_test! (
-    EthApi:uncle_count:uncle_count_by_hash, BlockId::Hash("0x123".into())
+    Eth:uncle_count:uncle_count_by_hash, BlockId::Hash("0x123".into())
     =>
     "eth_getUncleCountByBlockHash", vec![r#""0x123""#];
     Value::String("0x123".into())=> Some("0x123".into())
   );
 
   rpc_test! (
-    EthApi:uncle_count:uncle_count_by_no, BlockNumber::Earliest
+    Eth:uncle_count:uncle_count_by_no, BlockNumber::Earliest
     =>
     "eth_getUncleCountByBlockNumber", vec![r#""earliest""#];
     Value::Null => None
   );
 
   rpc_test! (
-    EthApi:work => "eth_getWork";
+    Eth:work => "eth_getWork";
     Value::Null => ()
   );
 
   rpc_test! (
-    EthApi:hashrate => "eth_hashrate";
+    Eth:hashrate => "eth_hashrate";
     Value::String("0x123".into()) => "0x123"
   );
 
   rpc_test! (
-    EthApi:mining => "eth_mining";
+    Eth:mining => "eth_mining";
     Value::Bool(true) => true
   );
 
   rpc_test! (
-    EthApi:new_block_filter => "eth_newBlockFilter";
+    Eth:new_block_filter => "eth_newBlockFilter";
     Value::String("0x123".into()) => "0x123"
   );
   rpc_test! (
-    EthApi:new_pending_transaction_filter => "eth_newPendingTransactionFilter";
-    Value::String("0x123".into()) => "0x123"
-  );
-
-  rpc_test! (
-    EthApi:protocol_version => "eth_protocolVersion";
+    Eth:new_pending_transaction_filter => "eth_newPendingTransactionFilter";
     Value::String("0x123".into()) => "0x123"
   );
 
   rpc_test! (
-    EthApi:send_raw_transaction, Bytes(vec![1, 2, 3, 4])
+    Eth:protocol_version => "eth_protocolVersion";
+    Value::String("0x123".into()) => "0x123"
+  );
+
+  rpc_test! (
+    Eth:send_raw_transaction, Bytes(vec![1, 2, 3, 4])
     =>
     "eth_sendRawTransaction", vec![r#""0x01020304""#];
     Value::String("0x123".into()) => "0x123"
   );
 
   rpc_test! (
-    EthApi:send_transaction, TransactionRequest {
+    Eth:send_transaction, TransactionRequest {
       from: "0x123".into(), to: Some("0x123".into()),
       gas: None, gas_price: Some("0x1".into()),
       value: Some("0x1".into()), data: None,
@@ -594,28 +527,28 @@ mod tests {
   );
 
   rpc_test! (
-    EthApi:sign, "0x123", Bytes(vec![1, 2, 3, 4])
+    Eth:sign, "0x123", Bytes(vec![1, 2, 3, 4])
     =>
     "eth_sign", vec![r#""0x123""#, r#""0x01020304""#];
     Value::String("0x123".into()) => "0x123"
   );
 
   rpc_test! (
-    EthApi:submit_hashrate, "0x123", "0x456"
+    Eth:submit_hashrate, "0x123", "0x456"
     =>
     "eth_submitHashrate", vec![r#""0x123""#, r#""0x456""#];
     Value::Bool(true) => true
   );
 
   rpc_test! (
-    EthApi:submit_work, "0x123", "0x456", "0x789"
+    Eth:submit_work, "0x123", "0x456", "0x789"
     =>
     "eth_submitWork", vec![r#""0x123""#, r#""0x456""#, r#""0x789""#];
     Value::Bool(true) => true
   );
 
   rpc_test! (
-    EthApi:syncing => "eth_syncing";
+    Eth:syncing => "eth_syncing";
     Value::Bool(true) => true
   );
 }

--- a/src/api/eth.rs
+++ b/src/api/eth.rs
@@ -3,7 +3,7 @@
 use futures::Future;
 
 use api::Namespace;
-use helpers;
+use helpers::{self, CallResult};
 use types::{
   Address, Block, BlockId, BlockNumber, Bytes, CallRequest,
   H64, H256, H512, Index,
@@ -13,103 +13,103 @@ use types::{
 use {Result, Transport};
 
 /// List of methods from `eth` namespace
-pub trait Eth {
+pub trait Eth<T: Transport> {
   /// Get list of available accounts.
-  fn accounts(&self) -> Result<Vec<Address>>;
+  fn accounts(&self) -> CallResult<Vec<Address>, T::Out>;
 
   /// Get current block number
-  fn block_number(&self) -> Result<U256>;
+  fn block_number(&self) -> CallResult<U256, T::Out>;
 
   /// Call a constant method of contract without changing the state of the blockchain.
-  fn call(&self, options: CallRequest, block: Option<BlockNumber>) -> Result<Bytes>;
+  fn call(&self, options: CallRequest, block: Option<BlockNumber>) -> CallResult<Bytes, T::Out>;
 
   /// Get coinbase address
-  fn coinbase(&self) -> Result<Address>;
+  fn coinbase(&self) -> CallResult<Address, T::Out>;
 
   /// Compile LLL
-  fn compile_lll(&self, String) -> Result<Bytes>;
+  fn compile_lll(&self, String) -> CallResult<Bytes, T::Out>;
 
   /// Compile Solidity
-  fn compile_solidity(&self, String) -> Result<Bytes>;
+  fn compile_solidity(&self, String) -> CallResult<Bytes, T::Out>;
 
   /// Compile Serpent
-  fn compile_serpent(&self, String) -> Result<Bytes>;
+  fn compile_serpent(&self, String) -> CallResult<Bytes, T::Out>;
 
   /// Call a contract without changing the state of the blockchain to estimate gas usage.
-  fn estimate_gas(&self, options: CallRequest, block: Option<BlockNumber>) -> Result<U256>;
+  fn estimate_gas(&self, options: CallRequest, block: Option<BlockNumber>) -> CallResult<U256, T::Out>;
 
   /// Get current recommended gas price
-  fn gas_price(&self) -> Result<U256>;
+  fn gas_price(&self) -> CallResult<U256, T::Out>;
 
   /// Get balance of given address
-  fn balance(&self, address: Address, block: Option<BlockNumber>) -> Result<U256>;
+  fn balance(&self, address: Address, block: Option<BlockNumber>) -> CallResult<U256, T::Out>;
 
   /// Get block details
-  fn block(&self, block: BlockId, include_txs: bool) -> Result<Block>;
+  fn block(&self, block: BlockId, include_txs: bool) -> CallResult<Block, T::Out>;
 
   /// Get number of transactions in block
-  fn block_transaction_count(&self, block: BlockId) -> Result<Option<U256>>;
+  fn block_transaction_count(&self, block: BlockId) -> CallResult<Option<U256>, T::Out>;
 
   /// Get code under given address
-  fn code(&self, address: Address, block: Option<BlockNumber>) -> Result<Bytes>;
+  fn code(&self, address: Address, block: Option<BlockNumber>) -> CallResult<Bytes, T::Out>;
 
   /// Get supported compilers
-  fn compilers(&self) -> Result<Vec<String>>;
+  fn compilers(&self) -> CallResult<Vec<String>, T::Out>;
 
   /// Get storage entry
-  fn storage(&self, address: Address, idx: U256, block: Option<BlockNumber>) -> Result<H256>;
+  fn storage(&self, address: Address, idx: U256, block: Option<BlockNumber>) -> CallResult<H256, T::Out>;
 
   /// Get nonce
-  fn transaction_count(&self, address: Address, block: Option<BlockNumber>) -> Result<U256>;
+  fn transaction_count(&self, address: Address, block: Option<BlockNumber>) -> CallResult<U256, T::Out>;
 
   /// Get transaction
-  fn transaction(&self, id: TransactionId) -> Result<Option<Transaction>>;
+  fn transaction(&self, id: TransactionId) -> CallResult<Option<Transaction>, T::Out>;
 
   /// Get transaction receipt
-  fn transaction_receipt(&self, hash: H256) -> Result<Option<TransactionReceipt>>;
+  fn transaction_receipt(&self, hash: H256) -> CallResult<Option<TransactionReceipt>, T::Out>;
 
   /// Get uncle
-  fn uncle(&self, block: BlockId, index: Index) -> Result<Option<Block>>;
+  fn uncle(&self, block: BlockId, index: Index) -> CallResult<Option<Block>, T::Out>;
 
   /// Get uncle count in block
-  fn uncle_count(&self, block: BlockId) -> Result<Option<U256>>;
+  fn uncle_count(&self, block: BlockId) -> CallResult<Option<U256>, T::Out>;
 
   /// Get work package
-  fn work(&self) -> Result<Work>;
+  fn work(&self) -> CallResult<Work, T::Out>;
 
   /// Get hash rate
-  fn hashrate(&self) -> Result<U256>;
+  fn hashrate(&self) -> CallResult<U256, T::Out>;
 
   /// Get mining status
-  fn mining(&self) -> Result<bool>;
+  fn mining(&self) -> CallResult<bool, T::Out>;
 
   /// Start new block filter
-  fn new_block_filter(&self) -> Result<U256>;
+  fn new_block_filter(&self) -> CallResult<U256, T::Out>;
 
   /// Start new pending transaction filter
-  fn new_pending_transaction_filter(&self) -> Result<U256>;
+  fn new_pending_transaction_filter(&self) -> CallResult<U256, T::Out>;
 
   /// Start new pending transaction filter
-  fn protocol_version(&self) -> Result<String>;
+  fn protocol_version(&self) -> CallResult<String, T::Out>;
 
   /// Sends a rlp-encoded signed transaction
-  fn send_raw_transaction(&self, rlp: Bytes) -> Result<H256>;
+  fn send_raw_transaction(&self, rlp: Bytes) -> CallResult<H256, T::Out>;
 
   /// Sends a transaction transaction
-  fn send_transaction(&self, tx: TransactionRequest) -> Result<H256>;
+  fn send_transaction(&self, tx: TransactionRequest) -> CallResult<H256, T::Out>;
 
   /// Signs a hash of given data
-  fn sign(&self, address: Address, data: Bytes) -> Result<H512>;
+  fn sign(&self, address: Address, data: Bytes) -> CallResult<H512, T::Out>;
 
   /// Submit hashrate of external miner
-  fn submit_hashrate(&self, rate: U256, id: H256) -> Result<bool>;
+  fn submit_hashrate(&self, rate: U256, id: H256) -> CallResult<bool, T::Out>;
 
   /// Submit work of external miner
-  fn submit_work(&self, nonce: H64, pow_hash: H256, mix_hash: H256) -> Result<bool>;
+  fn submit_work(&self, nonce: H64, pow_hash: H256, mix_hash: H256) -> CallResult<bool, T::Out>;
 
   // TODO [ToDr] Proper type?
   /// Get syncing status
-  fn syncing(&self) -> Result<bool>;
+  fn syncing(&self) -> CallResult<bool, T::Out>;
 }
 
 /// `Eth` namespace
@@ -125,80 +125,60 @@ impl<'a, T: Transport + 'a> Namespace<'a, T> for EthApi<'a, T> {
   }
 }
 
-impl<'a, T: Transport + 'a> Eth for EthApi<'a, T> {
-  fn accounts(&self) -> Result<Vec<Address>> {
-    self.transport.execute("eth_accounts", vec![])
-      .and_then(helpers::to_vector)
-      .boxed()
+impl<'a, T: Transport + 'a> Eth<T> for EthApi<'a, T> {
+  fn accounts(&self) -> CallResult<Vec<Address>, T::Out> {
+    CallResult::new(self.transport.execute("eth_accounts", vec![]))
   }
 
-  fn block_number(&self) -> Result<U256> {
-    self.transport.execute("eth_blockNumber", vec![])
-      .and_then(helpers::to_u256)
-      .boxed()
+  fn block_number(&self) -> CallResult<U256, T::Out> {
+    CallResult::new(self.transport.execute("eth_blockNumber", vec![]))
   }
 
-  fn call(&self, req: CallRequest, block: Option<BlockNumber>) -> Result<Bytes> {
+  fn call(&self, req: CallRequest, block: Option<BlockNumber>) -> CallResult<Bytes, T::Out> {
     let req = helpers::serialize(&req);
     let block = helpers::serialize(&block.unwrap_or(BlockNumber::Latest));
 
-    self.transport.execute("eth_call", vec![req, block])
-      .and_then(helpers::to_bytes)
-      .boxed()
+    CallResult::new(self.transport.execute("eth_call", vec![req, block]))
   }
 
-  fn coinbase(&self) -> Result<Address> {
-    self.transport.execute("eth_coinbase", vec![])
-      .and_then(helpers::to_address)
-      .boxed()
+  fn coinbase(&self) -> CallResult<Address, T::Out> {
+    CallResult::new(self.transport.execute("eth_coinbase", vec![]))
   }
 
-  fn compile_lll(&self, code: String) -> Result<Bytes> {
+  fn compile_lll(&self, code: String) -> CallResult<Bytes, T::Out> {
     let code = helpers::serialize(&code);
-    self.transport.execute("eth_compileLLL", vec![code])
-      .and_then(helpers::to_bytes)
-      .boxed()
+    CallResult::new(self.transport.execute("eth_compileLLL", vec![code]))
   }
 
-  fn compile_solidity(&self, code: String) -> Result<Bytes> {
+  fn compile_solidity(&self, code: String) -> CallResult<Bytes, T::Out> {
     let code = helpers::serialize(&code);
-    self.transport.execute("eth_compileSolidity", vec![code])
-      .and_then(helpers::to_bytes)
-      .boxed()
+    CallResult::new(self.transport.execute("eth_compileSolidity", vec![code]))
   }
 
-  fn compile_serpent(&self, code: String) -> Result<Bytes> {
+  fn compile_serpent(&self, code: String) -> CallResult<Bytes, T::Out> {
     let code = helpers::serialize(&code);
-    self.transport.execute("eth_compileSerpent", vec![code])
-      .and_then(helpers::to_bytes)
-      .boxed()
+    CallResult::new(self.transport.execute("eth_compileSerpent", vec![code]))
   }
 
-  fn estimate_gas(&self, req: CallRequest, block: Option<BlockNumber>) -> Result<U256> {
+  fn estimate_gas(&self, req: CallRequest, block: Option<BlockNumber>) -> CallResult<U256, T::Out> {
     let req = helpers::serialize(&req);
     let block = helpers::serialize(&block.unwrap_or(BlockNumber::Latest));
 
-    self.transport.execute("eth_estimateGas", vec![req, block])
-      .and_then(helpers::to_u256)
-      .boxed()
+    CallResult::new(self.transport.execute("eth_estimateGas", vec![req, block]))
   }
 
-  fn gas_price(&self) -> Result<U256> {
-    self.transport.execute("eth_gasPrice", vec![])
-      .and_then(helpers::to_u256)
-      .boxed()
+  fn gas_price(&self) -> CallResult<U256, T::Out> {
+    CallResult::new(self.transport.execute("eth_gasPrice", vec![]))
   }
 
-  fn balance(&self, address: Address, block: Option<BlockNumber>) -> Result<U256> {
+  fn balance(&self, address: Address, block: Option<BlockNumber>) -> CallResult<U256, T::Out> {
     let address = helpers::serialize(&address);
     let block = helpers::serialize(&block.unwrap_or(BlockNumber::Latest));
 
-    self.transport.execute("eth_getBalance", vec![address, block])
-      .and_then(helpers::to_u256)
-      .boxed()
+    CallResult::new(self.transport.execute("eth_getBalance", vec![address, block]))
   }
 
-  fn block(&self, block: BlockId, include_txs: bool) -> Result<Block> {
+  fn block(&self, block: BlockId, include_txs: bool) -> CallResult<Block, T::Out> {
     let include_txs = helpers::serialize(&include_txs);
 
     let result = match block {
@@ -212,12 +192,10 @@ impl<'a, T: Transport + 'a> Eth for EthApi<'a, T> {
       },
     };
 
-    result
-      .and_then(|_| Ok(()))
-      .boxed()
+    CallResult::new(result)
   }
 
-  fn block_transaction_count(&self, block: BlockId) -> Result<Option<U256>> {
+  fn block_transaction_count(&self, block: BlockId) -> CallResult<Option<U256>, T::Out> {
     let result = match block {
       BlockId::Hash(hash) => {
         let hash = helpers::serialize(&hash);
@@ -229,46 +207,36 @@ impl<'a, T: Transport + 'a> Eth for EthApi<'a, T> {
       },
     };
 
-    result
-      .and_then(helpers::to_u256_option)
-      .boxed()
+    CallResult::new(result)
   }
 
-  fn code(&self, address: Address, block: Option<BlockNumber>) -> Result<Bytes> {
+  fn code(&self, address: Address, block: Option<BlockNumber>) -> CallResult<Bytes, T::Out> {
     let address = helpers::serialize(&address);
     let block = helpers::serialize(&block.unwrap_or(BlockNumber::Latest));
 
-    self.transport.execute("eth_getCode", vec![address, block])
-      .and_then(helpers::to_bytes)
-      .boxed()
+    CallResult::new(self.transport.execute("eth_getCode", vec![address, block]))
   }
 
-  fn compilers(&self) -> Result<Vec<String>> {
-    self.transport.execute("eth_getCompilers", vec![])
-      .and_then(helpers::to_vector)
-      .boxed()
+  fn compilers(&self) -> CallResult<Vec<String>, T::Out> {
+    CallResult::new(self.transport.execute("eth_getCompilers", vec![]))
   }
 
-  fn storage(&self, address: Address, idx: U256, block: Option<BlockNumber>) -> Result<H256> {
+  fn storage(&self, address: Address, idx: U256, block: Option<BlockNumber>) -> CallResult<H256, T::Out> {
     let address = helpers::serialize(&address);
     let idx = helpers::serialize(&idx);
     let block = helpers::serialize(&block.unwrap_or(BlockNumber::Latest));
 
-    self.transport.execute("eth_getStorageAt", vec![address, idx, block])
-      .and_then(helpers::to_h256)
-      .boxed()
+    CallResult::new(self.transport.execute("eth_getStorageAt", vec![address, idx, block]))
   }
 
-  fn transaction_count(&self, address: Address, block: Option<BlockNumber>) -> Result<U256> {
+  fn transaction_count(&self, address: Address, block: Option<BlockNumber>) -> CallResult<U256, T::Out> {
     let address = helpers::serialize(&address);
     let block = helpers::serialize(&block.unwrap_or(BlockNumber::Latest));
 
-   self.transport.execute("eth_getTransactionCount", vec![address, block])
-      .and_then(helpers::to_u256)
-      .boxed()
+   CallResult::new(self.transport.execute("eth_getTransactionCount", vec![address, block]))
   }
 
-  fn transaction(&self, id: TransactionId) -> Result<Option<Transaction>> {
+  fn transaction(&self, id: TransactionId) -> CallResult<Option<Transaction>, T::Out> {
     let result = match id {
       TransactionId::Hash(hash) => {
         let hash = helpers::serialize(&hash);
@@ -286,20 +254,16 @@ impl<'a, T: Transport + 'a> Eth for EthApi<'a, T> {
       },
     };
 
-    result
-      .and_then(|_| Ok(Some(())))
-      .boxed()
+    CallResult::new(result)
   }
 
-  fn transaction_receipt(&self, hash: H256) -> Result<Option<TransactionReceipt>> {
+  fn transaction_receipt(&self, hash: H256) -> CallResult<Option<TransactionReceipt>, T::Out> {
     let hash = helpers::serialize(&hash);
 
-    self.transport.execute("eth_getTransactionReceipt", vec![hash])
-      .and_then(|_| Ok(Some(())))
-      .boxed()
+    CallResult::new(self.transport.execute("eth_getTransactionReceipt", vec![hash]))
   }
 
-  fn uncle(&self, block: BlockId, index: Index) -> Result<Option<Block>> {
+  fn uncle(&self, block: BlockId, index: Index) -> CallResult<Option<Block>, T::Out> {
     let index = helpers::serialize(&index);
 
     let result = match block {
@@ -313,12 +277,10 @@ impl<'a, T: Transport + 'a> Eth for EthApi<'a, T> {
       },
     };
 
-    result
-      .and_then(|_| Ok(Some(())))
-      .boxed()
+    CallResult::new(result)
   }
 
-  fn uncle_count(&self, block: BlockId) -> Result<Option<U256>> {
+  fn uncle_count(&self, block: BlockId) -> CallResult<Option<U256>, T::Out> {
     let result = match block {
       BlockId::Hash(hash) => {
         let hash = helpers::serialize(&hash);
@@ -330,90 +292,64 @@ impl<'a, T: Transport + 'a> Eth for EthApi<'a, T> {
       },
     };
 
-    result
-      .and_then(helpers::to_u256_option)
-      .boxed()
+    CallResult::new(result)
   }
 
-  fn work(&self) -> Result<Work> {
-    self.transport.execute("eth_getWork", vec![])
-      .and_then(|_| Ok(()))
-      .boxed()
+  fn work(&self) -> CallResult<Work, T::Out> {
+    CallResult::new(self.transport.execute("eth_getWork", vec![]))
   }
 
-  fn hashrate(&self) -> Result<U256> {
-    self.transport.execute("eth_hashrate", vec![])
-      .and_then(helpers::to_u256)
-      .boxed()
+  fn hashrate(&self) -> CallResult<U256, T::Out> {
+    CallResult::new(self.transport.execute("eth_hashrate", vec![]))
   }
 
-  fn mining(&self) -> Result<bool> {
-    self.transport.execute("eth_mining", vec![])
-      .and_then(helpers::to_bool)
-      .boxed()
+  fn mining(&self) -> CallResult<bool, T::Out> {
+    CallResult::new(self.transport.execute("eth_mining", vec![]))
   }
 
-  fn new_block_filter(&self) -> Result<U256> {
-    self.transport.execute("eth_newBlockFilter", vec![])
-      .and_then(helpers::to_u256)
-      .boxed()
+  fn new_block_filter(&self) -> CallResult<U256, T::Out> {
+    CallResult::new(self.transport.execute("eth_newBlockFilter", vec![]))
   }
 
-  fn new_pending_transaction_filter(&self) -> Result<U256> {
-    self.transport.execute("eth_newPendingTransactionFilter", vec![])
-      .and_then(helpers::to_u256)
-      .boxed()
+  fn new_pending_transaction_filter(&self) -> CallResult<U256, T::Out> {
+    CallResult::new(self.transport.execute("eth_newPendingTransactionFilter", vec![]))
   }
 
-  fn protocol_version(&self) -> Result<String> {
-    self.transport.execute("eth_protocolVersion", vec![])
-      .and_then(helpers::to_string)
-      .boxed()
+  fn protocol_version(&self) -> CallResult<String, T::Out> {
+    CallResult::new(self.transport.execute("eth_protocolVersion", vec![]))
   }
 
-  fn send_raw_transaction(&self, rlp: Bytes) -> Result<H256> {
+  fn send_raw_transaction(&self, rlp: Bytes) -> CallResult<H256, T::Out> {
     let rlp = helpers::serialize(&rlp);
-    self.transport.execute("eth_sendRawTransaction", vec![rlp])
-      .and_then(helpers::to_h256)
-      .boxed()
+    CallResult::new(self.transport.execute("eth_sendRawTransaction", vec![rlp]))
   }
 
-  fn send_transaction(&self, tx: TransactionRequest) -> Result<H256> {
+  fn send_transaction(&self, tx: TransactionRequest) -> CallResult<H256, T::Out> {
     let tx = helpers::serialize(&tx);
-    self.transport.execute("eth_sendTransaction", vec![tx])
-      .and_then(helpers::to_h256)
-      .boxed()
+    CallResult::new(self.transport.execute("eth_sendTransaction", vec![tx]))
   }
 
-  fn sign(&self, address: Address, data: Bytes) -> Result<H512> {
+  fn sign(&self, address: Address, data: Bytes) -> CallResult<H512, T::Out> {
     let address = helpers::serialize(&address);
     let data = helpers::serialize(&data);
-    self.transport.execute("eth_sign", vec![address, data])
-      .and_then(helpers::to_h512)
-      .boxed()
+    CallResult::new(self.transport.execute("eth_sign", vec![address, data]))
   }
 
-  fn submit_hashrate(&self, rate: U256, id: H256) -> Result<bool> {
+  fn submit_hashrate(&self, rate: U256, id: H256) -> CallResult<bool, T::Out> {
     let rate = helpers::serialize(&rate);
     let id = helpers::serialize(&id);
-    self.transport.execute("eth_submitHashrate", vec![rate, id])
-      .and_then(helpers::to_bool)
-      .boxed()
+    CallResult::new(self.transport.execute("eth_submitHashrate", vec![rate, id]))
   }
 
-  fn submit_work(&self, nonce: H64, pow_hash: H256, mix_hash: H256) -> Result<bool> {
+  fn submit_work(&self, nonce: H64, pow_hash: H256, mix_hash: H256) -> CallResult<bool, T::Out> {
     let nonce = helpers::serialize(&nonce);
     let pow_hash = helpers::serialize(&pow_hash);
     let mix_hash = helpers::serialize(&mix_hash);
-    self.transport.execute("eth_submitWork", vec![nonce, pow_hash, mix_hash])
-      .and_then(helpers::to_bool)
-      .boxed()
+    CallResult::new(self.transport.execute("eth_submitWork", vec![nonce, pow_hash, mix_hash]))
   }
 
-  fn syncing(&self) -> Result<bool> {
-    self.transport.execute("eth_syncing", vec![])
-      .and_then(helpers::to_bool)
-      .boxed()
+  fn syncing(&self) -> CallResult<bool, T::Out> {
+    CallResult::new(self.transport.execute("eth_syncing", vec![]))
   }
 }
 
@@ -553,7 +489,7 @@ mod tests {
     EthApi:transaction:tx_by_hash, TransactionId::Hash("0x123".into())
     =>
     "eth_getTransactionByHash", vec![r#""0x123""#];
-    Value::Null => Some(())
+    Value::Array(vec![]) => Some(())
   );
 
   rpc_test! (
@@ -563,7 +499,7 @@ mod tests {
     )
     =>
     "eth_getTransactionByBlockHashAndIndex", vec![r#""0x123""#, r#""0x5""#];
-    Value::Null => Some(())
+    Value::Array(vec![]) => Some(())
   );
 
   rpc_test! (
@@ -573,28 +509,28 @@ mod tests {
     )
     =>
     "eth_getTransactionByBlockNumberAndIndex", vec![r#""pending""#, r#""0x5""#];
-    Value::Null => Some(())
+    Value::Array(vec![]) => Some(())
   );
 
   rpc_test! (
     EthApi:transaction_receipt, "0x123".to_owned()
     =>
     "eth_getTransactionReceipt", vec![r#""0x123""#];
-    Value::Null => Some(())
+    Value::Array(vec![]) => Some(())
   );
 
   rpc_test! (
     EthApi:uncle:uncle_by_hash, BlockId::Hash("0x123".into()), "0x5"
     =>
     "eth_getUncleByBlockHashAndIndex", vec![r#""0x123""#, r#""0x5""#];
-    Value::Null => Some(())
+    Value::Array(vec![]) => Some(())
   );
 
   rpc_test! (
     EthApi:uncle:uncle_by_no, BlockNumber::Earliest, "0x5"
     =>
     "eth_getUncleByBlockNumberAndIndex", vec![r#""earliest""#, r#""0x5""#];
-    Value::Null => Some(())
+    Value::Array(vec![]) => Some(())
   );
 
   rpc_test! (

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -35,7 +35,7 @@ impl<T: Transport> Web3Main<T> {
   }
 
   /// Access methods from `eth` namespace
-  pub fn eth(&self) -> eth::EthApi<T> {
+  pub fn eth(&self) -> eth::Eth<T> {
     self.api()
   }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -40,12 +40,12 @@ impl<T: Transport> Web3Main<T> {
   }
 
   /// Access methods from `net` namespace
-  pub fn net(&self) -> net::NetApi<T> {
+  pub fn net(&self) -> net::Net<T> {
     self.api()
   }
 
   /// Access methods from `web3` namespace
-  pub fn web3(&self) -> web3::Web3Api<T> {
+  pub fn web3(&self) -> web3::Web3<T> {
     self.api()
   }
 

--- a/src/api/net.rs
+++ b/src/api/net.rs
@@ -3,52 +3,34 @@
 use futures::Future;
 
 use api::Namespace;
-use helpers;
+use helpers::{self, CallResult};
 
 use {Result, Transport};
 
-/// List of methods from `net` namespace
-pub trait Net {
-  /// Returns protocol version
-  fn version(&self) -> Result<String>;
-
-  /// Returns numbers of peers connected to node.
-  fn peer_count(&self) -> Result<String>;
-
-  /// Returns true if client is actively listening for network connections.
-  fn is_listening(&self) -> Result<bool>;
-}
-
-/// `NetApi` namespace
-pub struct NetApi<'a, T: 'a> {
+/// `Net` namespace
+pub struct Net<'a, T: 'a> {
   transport: &'a T,
 }
 
-impl<'a, T: Transport + 'a> Namespace<'a, T> for NetApi<'a, T> {
+impl<'a, T: Transport + 'a> Namespace<'a, T> for Net<'a, T> {
   fn new(transport: &'a T) -> Self where Self: Sized {
-    NetApi {
+    Net {
       transport: transport,
     }
   }
 }
 
-impl<'a, T: Transport + 'a> Net for NetApi<'a, T> {
-  fn version(&self) -> Result<String> {
-    self.transport.execute("net_version", vec![])
-      .and_then(helpers::to_string)
-      .boxed()
+impl<'a, T: Transport + 'a> Net<'a, T> {
+  pub fn version(&self) -> CallResult<String, T::Out> {
+    CallResult::new(self.transport.execute("net_version", vec![]))
   }
 
-  fn peer_count(&self) -> Result<String> {
-    self.transport.execute("net_peerCount", vec![])
-      .and_then(helpers::to_string)
-      .boxed()
+  pub fn peer_count(&self) -> CallResult<String, T::Out> {
+    CallResult::new(self.transport.execute("net_peerCount", vec![]))
   }
 
-  fn is_listening(&self) -> Result<bool> {
-    self.transport.execute("net_listening", vec![])
-      .and_then(helpers::to_bool)
-      .boxed()
+  pub fn is_listening(&self) -> CallResult<bool, T::Out> {
+    CallResult::new(self.transport.execute("net_listening", vec![]))
   }
 }
 
@@ -59,20 +41,20 @@ mod tests {
   use api::Namespace;
   use rpc::Value;
 
-  use super::{NetApi, Net};
+  use super::Net;
 
   rpc_test! (
-    NetApi:version => "net_version";
+    Net:version => "net_version";
     Value::String("Test123".into()) => "Test123"
   );
 
   rpc_test! (
-    NetApi:peer_count => "net_peerCount";
+    Net:peer_count => "net_peerCount";
     Value::String("Test123".into()) => "Test123"
   );
 
   rpc_test! (
-    NetApi:is_listening => "net_listening";
+    Net:is_listening => "net_listening";
     Value::Bool(true) => true
   );
 }

--- a/src/api/net.rs
+++ b/src/api/net.rs
@@ -1,11 +1,9 @@
 //! `Net` namespace
 
-use futures::Future;
-
 use api::Namespace;
-use helpers::{self, CallResult};
+use helpers::CallResult;
 
-use {Result, Transport};
+use {Transport};
 
 /// `Net` namespace
 pub struct Net<'a, T: 'a> {
@@ -21,14 +19,17 @@ impl<'a, T: Transport + 'a> Namespace<'a, T> for Net<'a, T> {
 }
 
 impl<'a, T: Transport + 'a> Net<'a, T> {
+  /// Returns protocol version
   pub fn version(&self) -> CallResult<String, T::Out> {
     CallResult::new(self.transport.execute("net_version", vec![]))
   }
 
+  /// Returns number of peers connected to node.
   pub fn peer_count(&self) -> CallResult<String, T::Out> {
     CallResult::new(self.transport.execute("net_peerCount", vec![]))
   }
 
+  /// Whether the node is listening for network connections
   pub fn is_listening(&self) -> CallResult<bool, T::Out> {
     CallResult::new(self.transport.execute("net_listening", vec![]))
   }

--- a/src/api/web3.rs
+++ b/src/api/web3.rs
@@ -1,12 +1,10 @@
 //! `Web3` namespace
 
-use futures::Future;
-
 use api::Namespace;
 use helpers::{self, CallResult};
 use types::{Bytes, H256};
 
-use {Result, Transport};
+use {Transport};
 
 /// `Web3` namespace
 pub struct Web3<'a, T: 'a> {

--- a/src/api/web3.rs
+++ b/src/api/web3.rs
@@ -3,45 +3,34 @@
 use futures::Future;
 
 use api::Namespace;
-use helpers;
+use helpers::{self, CallResult};
 use types::{Bytes, H256};
 
 use {Result, Transport};
 
-/// List of methods from `web3` namespace
-pub trait Web3 {
-  /// Returns client version
-  fn client_version(&self) -> Result<String>;
-
-  /// Returns sha3 of the given data
-  fn sha3(&self, bytes: Bytes) -> Result<H256>;
-}
-
-/// `Web3Api` namespace
-pub struct Web3Api<'a, T: 'a> {
+/// `Web3` namespace
+pub struct Web3<'a, T: 'a> {
   transport: &'a T,
 }
 
-impl<'a, T: Transport + 'a> Namespace<'a, T> for Web3Api<'a, T> {
+impl<'a, T: Transport + 'a> Namespace<'a, T> for Web3<'a, T> {
   fn new(transport: &'a T) -> Self where Self: Sized {
-    Web3Api {
+    Web3 {
       transport: transport,
     }
   }
 }
 
-impl<'a, T: Transport + 'a> Web3 for Web3Api<'a, T> {
-  fn client_version(&self) -> Result<String> {
-    self.transport.execute("web3_clientVersion", vec![])
-      .and_then(helpers::to_string)
-      .boxed()
+impl<'a, T: Transport + 'a> Web3<'a, T> {
+  /// Returns client version
+  pub fn client_version(&self) -> CallResult<String, T::Out> {
+    CallResult::new(self.transport.execute("web3_clientVersion", vec![]))
   }
 
-  fn sha3(&self, bytes: Bytes) -> Result<H256> {
+  /// Returns sha3 of the given data
+  pub fn sha3(&self, bytes: Bytes) -> CallResult<H256, T::Out> {
     let bytes = helpers::serialize(&bytes);
-    self.transport.execute("web3_sha3", vec![bytes])
-      .and_then(helpers::to_h256)
-      .boxed()
+    CallResult::new(self.transport.execute("web3_sha3", vec![bytes]))
   }
 }
 
@@ -53,15 +42,15 @@ mod tests {
   use types::{Bytes};
   use rpc::Value;
 
-  use super::{Web3, Web3Api};
+  use super::Web3;
 
   rpc_test! (
-    Web3Api:client_version => "web3_clientVersion";
+    Web3:client_version => "web3_clientVersion";
     Value::String("Test123".into()) => "Test123"
   );
 
   rpc_test! (
-    Web3Api:sha3, Bytes(vec![1, 2, 3, 4])
+    Web3:sha3, Bytes(vec![1, 2, 3, 4])
     =>
     "web3_sha3", vec![r#""0x01020304""#];
     Value::String("0x123".into()) => "0x123"

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -2,10 +2,8 @@ use std::marker::PhantomData;
 
 use rpc;
 use futures::{Async, Poll, Future};
-use rustc_serialize::hex::FromHex;
 use serde;
 use serde_json;
-use types;
 use {Error};
 
 /// Value-decoder future.
@@ -40,73 +38,6 @@ impl<T: serde::Deserialize, F> Future for CallResult<T, F>
 
 pub fn serialize<T: serde::Serialize>(t: &T) -> String {
   serde_json::to_string(t).expect("Types serialization is never failing.")
-}
-
-pub fn to_vector(val: rpc::Value) -> Result<Vec<String>, Error> {
-  let invalid = format!("Expected vector of strings, got {:?}", val);
-
-  if let rpc::Value::Array(val) = val {
-    val.into_iter().map(|v| match v {
-     rpc::Value::String(s) => Ok(s),
-      _ => Err(Error::InvalidResponse(invalid.clone())),
-    }).collect()
-  } else {
-    Err(Error::InvalidResponse(invalid))
-  }
-}
-
-pub fn to_u256(val: rpc::Value) -> Result<types::U256, Error> {
-  // TODO [ToDr] proper type
-  to_string(val)
-}
-
-pub fn to_h256(val: rpc::Value) -> Result<types::H256, Error> {
-  // TODO [ToDr] proper type
-  to_string(val)
-}
-
-pub fn to_h512(val: rpc::Value) -> Result<types::H512, Error> {
-  // TODO [ToDr] proper type
-  to_string(val)
-}
-
-pub fn to_u256_option(val: rpc::Value) -> Result<Option<types::U256>, Error> {
-  Ok(if val == rpc::Value::Null {
-    None
-  } else {
-    Some(to_u256(val)?)
-  })
-}
-
-pub fn to_address(val: rpc::Value) -> Result<types::Address, Error> {
-  // TODO [ToDr] proper type
-  to_string(val)
-}
-
-pub fn to_string(val: rpc::Value) -> Result<String, Error> {
-  if let rpc::Value::String(s) = val {
-    Ok(s)
-  } else {
-    Err(Error::InvalidResponse(format!("Expected string, got {:?}", val)))
-  }
-}
-
-pub fn to_bytes(val: rpc::Value) -> Result<types::Bytes, Error> {
-  if let rpc::Value::String(s) = val {
-    s[2..].from_hex().map(types::Bytes).map_err(|e| Error::InvalidResponse(
-      format!("Invalid hex string returned: {:?}", e)
-    ))
-  } else {
-    Err(Error::InvalidResponse(format!("Expected bytes, got {:?}", val)))
-  }
-}
-
-pub fn to_bool(val: rpc::Value) -> Result<bool, Error> {
-  if let rpc::Value::Bool(b) = val {
-    Ok(b)
-  } else {
-    Err(Error::InvalidResponse(format!("Expected bool, got {:?}", val)))
-  }
 }
 
 pub fn build_request(id: usize, method: &str, params: Vec<String>) -> String {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,24 +1,57 @@
+use std::marker::PhantomData;
+
 use rpc;
+use futures::{Async, Poll, Future};
 use rustc_serialize::hex::FromHex;
 use serde;
 use serde_json;
 use types;
 use {Error};
 
+/// Value-decoder future.
+/// Takes any type which is deserializable from rpc::Value,
+/// a future which yields that type, and
+pub struct CallResult<T, F> {
+  inner: F,
+  _marker: PhantomData<T>,
+}
+
+impl<T, F> CallResult<T, F> {
+  /// Create a new CallResult wrapping the inner future.
+  pub fn new(inner: F) -> Self {
+    CallResult { inner: inner, _marker: PhantomData }
+  }
+}
+
+impl<T: serde::Deserialize, F> Future for CallResult<T, F>
+  where F: Future<Item=rpc::Value, Error=Error>
+{
+  type Item = T;
+  type Error = Error;
+
+  fn poll(&mut self) -> Poll<T, Error> {
+    match self.inner.poll() {
+      Ok(Async::Ready(x)) => serde_json::from_value(x).map(Async::Ready).map_err(Into::into),
+      Ok(Async::NotReady) => Ok(Async::NotReady),
+      Err(e) => Err(e),
+    }
+  }
+}
+
 pub fn serialize<T: serde::Serialize>(t: &T) -> String {
   serde_json::to_string(t).expect("Types serialization is never failing.")
 }
 
 pub fn to_vector(val: rpc::Value) -> Result<Vec<String>, Error> {
-  let invalid = Error::InvalidResponse(format!("Expected vector of strings, got {:?}", val));
+  let invalid = format!("Expected vector of strings, got {:?}", val);
 
   if let rpc::Value::Array(val) = val {
     val.into_iter().map(|v| match v {
      rpc::Value::String(s) => Ok(s),
-      _ => Err(invalid.clone()),
+      _ => Err(Error::InvalidResponse(invalid.clone())),
     }).collect()
   } else {
-    Err(invalid)
+    Err(Error::InvalidResponse(invalid))
   }
 }
 
@@ -61,7 +94,7 @@ pub fn to_string(val: rpc::Value) -> Result<String, Error> {
 pub fn to_bytes(val: rpc::Value) -> Result<types::Bytes, Error> {
   if let rpc::Value::String(s) = val {
     s[2..].from_hex().map(types::Bytes).map_err(|e| Error::InvalidResponse(
-      format!("Invalid hex string returned: {:?}", e)      
+      format!("Invalid hex string returned: {:?}", e)
     ))
   } else {
     Err(Error::InvalidResponse(format!("Expected bytes, got {:?}", val)))
@@ -113,6 +146,8 @@ pub mod tests {
   }
 
   impl Transport for TestTransport {
+    type Out = Result<rpc::Value>;
+
     fn execute(&self, method: &str, params: Vec<String>) -> Result<rpc::Value> {
       self.requests.borrow_mut().push((method.into(), params));
       match self.response.borrow_mut().take() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub use api::Web3Main as Web3;
 pub type Result<T> = futures::BoxFuture<T, Error>;
 
 /// RPC error
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Error {
   /// Server is unreachable
   Unreachable,
@@ -32,12 +32,29 @@ pub enum Error {
   InvalidResponse(String),
   /// Transport Error
   Transport(String),
+  /// JSON decoding error.
+  Decoder(String),
   /// Error returned by RPC
   Rpc(rpc::Error),
 }
 
+impl From<serde_json::Error> for Error {
+  fn from(err: serde_json::Error) -> Self {
+    Error::Decoder(format!("{:?}", err))
+  }
+}
+
+impl From<rpc::Error> for Error {
+  fn from(err: rpc::Error) -> Self {
+    Error::Rpc(err)
+  }
+}
+
 /// Transport implementation
 pub trait Transport {
+  /// The type of future this transport returns when a call is made.
+  type Out: futures::Future<Item=rpc::Value, Error=Error> + Send + 'static;
+
   /// Execute remote method with given parameters.
-  fn execute(&self, method: &str, params: Vec<String>) -> Result<rpc::Value>;
+  fn execute(&self, method: &str, params: Vec<String>) -> Self::Out;
 }


### PR DESCRIPTION
Also closes #3 

Transports will now expose an `Out` future type which can be composed with a deserializing `CallResult` future (as a stopgap until `impl Trait`)

Hurts ergonomics slightly, but a future PR will allow manual erasure of the transport type.