### PR TITLE
Transport Erasure

### DIFF
--- a/src/api/eth.rs
+++ b/src/api/eth.rs
@@ -11,19 +11,19 @@ use types::{
 use {Transport};
 
 /// `Eth` namespace
-pub struct Eth<'a, T: 'a> {
-  transport: &'a T,
+pub struct Eth<T> {
+  transport: T,
 }
 
-impl<'a, T: Transport + 'a> Namespace<'a, T> for Eth<'a, T> {
-  fn new(transport: &'a T) -> Self where Self: Sized {
+impl<T: Transport> Namespace<T> for Eth<T> {
+  fn new(transport: T) -> Self where Self: Sized {
     Eth {
       transport: transport,
     }
   }
 }
 
-impl<'a, T: Transport + 'a> Eth<'a, T> {
+impl<T: Transport> Eth<T> {
   /// Get list of available accounts.
   pub fn accounts(&self) -> CallResult<Vec<Address>, T::Out> {
     CallResult::new(self.transport.execute("eth_accounts", vec![]))

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -11,15 +11,20 @@ pub use self::web3::Web3;
 use {Transport};
 
 /// Common API for all namespaces
-pub trait Namespace<'a, T: Transport + 'a> {
+pub trait Namespace<T: Transport> {
   /// Creates new API namespace
-  fn new(transport: &'a T) -> Self where Self: Sized;
+  fn new(transport: T) -> Self where Self: Sized;
 }
 
 /// `Web3` wrapper for all namespaces
 pub struct Web3Main<T: Transport> {
   transport: T,
 }
+
+/// Transport-erased `Web3 wrapper.
+/// Create this by calling `Web3Main::new` with a transport you've
+/// previously called `erase()` on.
+pub type ErasedWeb3 = Web3Main<::Erased>;
 
 impl<T: Transport> Web3Main<T> {
   /// Create new `Web3` with given transport
@@ -30,22 +35,22 @@ impl<T: Transport> Web3Main<T> {
   }
 
   /// Access methods from custom namespace
-  pub fn api<'a, A: Namespace<'a, T>>(&'a self) -> A {
+  pub fn api<'a, A: Namespace<&'a T>>(&'a self) -> A {
     A::new(&self.transport)
   }
 
   /// Access methods from `eth` namespace
-  pub fn eth(&self) -> eth::Eth<T> {
+  pub fn eth(&self) -> eth::Eth<&T> {
     self.api()
   }
 
   /// Access methods from `net` namespace
-  pub fn net(&self) -> net::Net<T> {
+  pub fn net(&self) -> net::Net<&T> {
     self.api()
   }
 
   /// Access methods from `web3` namespace
-  pub fn web3(&self) -> web3::Web3<T> {
+  pub fn web3(&self) -> web3::Web3<&T> {
     self.api()
   }
 

--- a/src/api/net.rs
+++ b/src/api/net.rs
@@ -6,19 +6,19 @@ use helpers::CallResult;
 use {Transport};
 
 /// `Net` namespace
-pub struct Net<'a, T: 'a> {
-  transport: &'a T,
+pub struct Net<T> {
+  transport: T,
 }
 
-impl<'a, T: Transport + 'a> Namespace<'a, T> for Net<'a, T> {
-  fn new(transport: &'a T) -> Self where Self: Sized {
+impl<T: Transport> Namespace<T> for Net<T> {
+  fn new(transport: T) -> Self where Self: Sized {
     Net {
       transport: transport,
     }
   }
 }
 
-impl<'a, T: Transport + 'a> Net<'a, T> {
+impl<T: Transport> Net<T> {
   /// Returns protocol version
   pub fn version(&self) -> CallResult<String, T::Out> {
     CallResult::new(self.transport.execute("net_version", vec![]))

--- a/src/api/web3.rs
+++ b/src/api/web3.rs
@@ -7,19 +7,19 @@ use types::{Bytes, H256};
 use {Transport};
 
 /// `Web3` namespace
-pub struct Web3<'a, T: 'a> {
-  transport: &'a T,
+pub struct Web3<T> {
+  transport: T,
 }
 
-impl<'a, T: Transport + 'a> Namespace<'a, T> for Web3<'a, T> {
-  fn new(transport: &'a T) -> Self where Self: Sized {
+impl<T: Transport> Namespace<T> for Web3<T> {
+  fn new(transport: T) -> Self where Self: Sized {
     Web3 {
       transport: transport,
     }
   }
 }
 
-impl<'a, T: Transport + 'a> Web3<'a, T> {
+impl<T: Transport> Web3<T> {
   /// Returns client version
   pub fn client_version(&self) -> CallResult<String, T::Out> {
     CallResult::new(self.transport.execute("web3_clientVersion", vec![]))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use futures::Future;
 pub mod api;
 pub mod transports;
 
-pub use api::Web3Main as Web3;
+pub use api::{Web3Main as Web3, ErasedWeb3};
 
 /// RPC result
 pub type Result<T> = futures::BoxFuture<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,11 +11,14 @@ extern crate serde_json;
 #[macro_use]
 extern crate log;
 
+mod types;
+
 #[macro_use]
 mod helpers;
 
+use futures::Future;
+
 pub mod api;
-mod types;
 pub mod transports;
 
 pub use api::Web3Main as Web3;
@@ -53,10 +56,40 @@ impl From<rpc::Error> for Error {
 /// Transport implementation
 pub trait Transport {
   /// The type of future this transport returns when a call is made.
-  type Out: futures::Future<Item=rpc::Value, Error=Error> + Send + 'static;
+  type Out: futures::Future<Item=rpc::Value, Error=Error>;
 
   /// Execute remote method with given parameters.
   fn execute(&self, method: &str, params: Vec<String>) -> Self::Out;
+
+  /// Erase the type of the transport by boxing it and boxing all produced
+  /// futures.
+  fn erase(self) -> Erased where Self: Sized + 'static, Self::Out: Send + 'static {
+    Erased(Box::new(Eraser(self)))
+  }
+}
+
+// Transport eraser.
+struct Eraser<T: Transport>(T);
+
+impl<T: Transport> Transport for Eraser<T>
+  where T::Out: Send + 'static
+{
+  type Out = Result<rpc::Value>;
+
+  fn execute(&self, method: &str, params: Vec<String>) -> Self::Out {
+    self.0.execute(method, params).boxed()
+  }
+}
+
+/// Transport with erased output type.
+pub struct Erased(Box<Transport<Out=Result<rpc::Value>>>);
+
+impl Transport for Erased {
+  type Out = Result<rpc::Value>;
+
+  fn execute(&self, method: &str, params: Vec<String>) -> Self::Out {
+    self.0.execute(method, params)
+  }
 }
 
 impl<'a, T: 'a + ?Sized> Transport for &'a T where T: Transport {


### PR DESCRIPTION
Allows erasing of the transport type for better ease-of-use without generic functions at a slight sacrifice of performance (by boxing the transport once and boxing each call result)

Also uses the new blanket impl from #1 to have namespaces take their transport by value, which is strictly more flexible.