### PR TITLE
Various small improvements

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,9 +1,9 @@
 //! `Web3` implementation
 
-pub mod eth;
-pub mod eth_filter;
-pub mod net;
-pub mod web3;
+mod eth;
+mod eth_filter;
+mod net;
+mod web3;
 
 pub use self::eth::Eth;
 pub use self::eth_filter::{EthFilter, LogsFilter, BlocksFilter, PendingTransactionsFilter};

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,4 +1,4 @@
-///! Web3 helpers.
+//! Web3 helpers.
 
 use std::marker::PhantomData;
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,3 +1,5 @@
+///! Web3 helpers.
+
 use std::marker::PhantomData;
 
 use rpc;
@@ -36,10 +38,12 @@ impl<T: serde::Deserialize, F> Future for CallResult<T, F>
   }
 }
 
+/// Serialize a type. Panics if the type is returns error during serialization.
 pub fn serialize<T: serde::Serialize>(t: &T) -> rpc::Value {
   serde_json::to_value(t).expect("Types never fail to serialize.")
 }
 
+/// Build a JSON-RPC request.
 pub fn build_request(id: usize, method: &str, params: Vec<rpc::Value>) -> String {
   let request = rpc::Request::Single(rpc::Call::MethodCall(rpc::MethodCall {
     jsonrpc: Some(rpc::Version::V2),
@@ -50,11 +54,13 @@ pub fn build_request(id: usize, method: &str, params: Vec<rpc::Value>) -> String
   serde_json::to_string(&request).expect("String serialization never fails.")
 }
 
+/// Parse bytes slice into JSON-RPC response.
 pub fn to_response_from_slice(response: &[u8]) -> Result<rpc::Response, Error> {
   serde_json::from_slice(response)
     .map_err(|e| Error::InvalidResponse(format!("{:?}", e)))
 }
 
+/// Parse `rpc::Output` into `Result`.
 pub fn to_result_from_output(output: rpc::Output) -> Result<rpc::Value, Error> {
   match output {
     rpc::Output::Success(success) => Ok(success.result),
@@ -62,6 +68,7 @@ pub fn to_result_from_output(output: rpc::Output) -> Result<rpc::Value, Error> {
   }
 }
 
+/// Parse string-encoded RPC response into `Result`.
 pub fn to_result(response: &str) -> Result<rpc::Value, Error> {
   let response = serde_json::from_str(response)
     .map_err(|e| Error::InvalidResponse(format!("{:?}", e)))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ extern crate serde_derive;
 pub extern crate futures;
 
 #[macro_use]
-mod helpers;
+pub mod helpers;
 
 use futures::Future;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ pub trait Transport {
 struct Eraser<T: Transport>(T);
 
 impl<T: Transport> Transport for Eraser<T>
-  where T::Out: Send + 'static
+  where T::Out: Send + 'static,
 {
   type Out = Result<rpc::Value>;
 
@@ -98,10 +98,39 @@ impl Transport for Erased {
   }
 }
 
-impl<'a, T: 'a + ?Sized> Transport for &'a T where T: Transport {
+impl<X, T> Transport for X where
+  T: Transport + ?Sized,
+  X: ::std::ops::Deref<Target=T>,
+{
   type Out = T::Out;
 
-  fn execute(&self, method: &str, params: Vec<rpc::Value>) -> T::Out {
-    (&**self).execute(method, params)
+  fn execute(&self, method: &str, params: Vec<rpc::Value>) -> Self::Out {
+    (**self).execute(method, params)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::sync::Arc;
+  use api::Web3Main;
+  use futures::BoxFuture;
+  use super::{rpc, Error, Transport};
+
+  struct FakeTransport;
+  impl Transport for FakeTransport {
+    type Out = BoxFuture<rpc::Value, Error>;
+
+    fn execute(&self, method: &str, params: Vec<rpc::Value>) -> Self::Out {
+      unimplemented!()
+    }
+  }
+
+  #[test]
+  fn should_allow_to_use_arc_as_transport() {
+    let transport = Arc::new(FakeTransport);
+    let transport2 = transport.clone();
+
+    let _web3_1 = Web3Main::new(transport);
+    let _web3_2 = Web3Main::new(transport2);
   }
 }

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -7,9 +7,9 @@ use rustc_serialize::hex::{FromHex, ToHex};
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Bytes(pub Vec<u8>);
 
-impl<'a> From<&'a [u8]> for Bytes {
-  fn from(data: &'a [u8]) -> Self {
-    Bytes(data.to_vec())
+impl<T: Into<Vec<u8>>> From<T> for Bytes {
+  fn from(data: T) -> Self {
+    Bytes(data.into())
   }
 }
 

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -7,6 +7,12 @@ use rustc_serialize::hex::{FromHex, ToHex};
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Bytes(pub Vec<u8>);
 
+impl<'a> From<&'a [u8]> for Bytes {
+  fn from(data: &'a [u8]) -> Self {
+    Bytes(data.to_vec())
+  }
+}
+
 impl Serialize for Bytes {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where S: Serializer {

--- a/src/types/uint.rs
+++ b/src/types/uint.rs
@@ -1,6 +1,6 @@
 use std::hash::{Hash, Hasher};
 use std::str::FromStr;
-use std::{cmp, fmt};
+use std::{cmp, fmt, ops};
 use serde;
 
 const PREFIX: usize = 2;
@@ -46,6 +46,13 @@ macro_rules! impl_uint {
   ($name: ident, $len: expr, $strict: expr) => {
     /// Uint serialization.
     pub struct $name(pub [u8; $len]);
+
+    impl ops::Deref for $name {
+      type Target = [u8];
+      fn deref(&self) -> &Self::Target {
+        &self.0
+      }
+    }
 
     impl Default for $name {
       fn default() -> Self {


### PR DESCRIPTION
- Expose `helpers` (makes it simpler to write custom APIs)
- Add `Deref<Target=[u8]>` to uints and `From<&[u8]>` for `Bytes`
- Make `Transport` blanket implementation more generic (covers `Arc` and `Rc`)