### PR TITLE
Fix backpressure in IPC transport.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ mod tests {
   impl Transport for FakeTransport {
     type Out = BoxFuture<rpc::Value, Error>;
 
-    fn execute(&self, method: &str, params: Vec<rpc::Value>) -> Self::Out {
+    fn execute(&self, _method: &str, _params: Vec<rpc::Value>) -> Self::Out {
       unimplemented!()
     }
   }


### PR DESCRIPTION
Cloning a channel creates a buffer slot for it which could result in unbounded queue if the requests are produced faster than they can be processed.