### PR TITLE
fixed TransactionReceipt fields && added tests for deserialization

### DIFF
--- a/src/confirm.rs
+++ b/src/confirm.rs
@@ -69,8 +69,8 @@ mod tests {
       condition: None,
     };
     let transaction_receipt = TransactionReceipt {
-      hash: 0.into(),
-      index: 0.into(),
+      transaction_hash: 0.into(),
+      transaction_index: 0.into(),
       block_hash: 0.into(),
       block_number: 2.into(),
       cumulative_gas_used: 0.into(),

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -34,6 +34,12 @@ pub struct Transaction {
 /// "Receipt" of an executed transaction: details of its execution.
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Receipt {
+  /// Transaction hash.
+  #[serde(rename="transactionHash")]
+  pub transaction_hash: H256,
+  /// Index within the block.
+  #[serde(rename="transactionIndex")]
+  pub transaction_index: Index,
   /// Hash of the block this transaction was included within.
   #[serde(rename="blockHash")]
   pub block_hash: H256,

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -34,10 +34,6 @@ pub struct Transaction {
 /// "Receipt" of an executed transaction: details of its execution.
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Receipt {
-  /// Hash
-  pub hash: H256,
-  /// Index within the block.
-  pub index: Index,
   /// Hash of the block this transaction was included within.
   #[serde(rename="blockHash")]
   pub block_hash: H256,
@@ -55,4 +51,18 @@ pub struct Receipt {
   pub contract_address: Option<H160>,
   /// Logs generated within this transaction.
   pub logs: Vec<Log>,
+}
+
+#[cfg(test)]
+mod tests {
+  use serde_json;
+  use super::Receipt;
+
+  #[test]
+  fn test_deserialize_receipt() {
+    let receipt_str = "{\"blockHash\":\"0x83eaba432089a0bfe99e9fc9022d1cfcb78f95f407821be81737c84ae0b439c5\",\"blockNumber\":\"0x38\",\"contractAddress\":\"0x03d8c4566478a6e1bf75650248accce16a98509f\",\"cumulativeGasUsed\":\"0x927c0\",\"gasUsed\":\"0x927c0\",\"logs\":[],\"logsBloom\":\"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\",\"root\":null,\"transactionHash\":\"0x422fb0d5953c0c48cbb42fb58e1c30f5e150441c68374d70ca7d4f191fd56f26\",\"transactionIndex\":\"0x0\"}";
+
+    let _receipt: Receipt = serde_json::from_str(receipt_str).unwrap();
+
+  }
 }


### PR DESCRIPTION
transaction receipt does not have fields called `index` and `hash` [docs](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_gettransactionreceipt)