### PR TITLE
Change the return type used for eth_sign from H512 to H520.

### DIFF
--- a/src/api/eth.rs
+++ b/src/api/eth.rs
@@ -4,7 +4,7 @@ use api::Namespace;
 use helpers::{self, CallResult};
 use types::{
   Address, Block, BlockId, BlockNumber, Bytes, CallRequest,
-  H64, H256, H512, Index,
+  H64, H256, H520, Index,
   Transaction, TransactionId, TransactionReceipt, TransactionRequest,
   U256, Work,
 };
@@ -279,7 +279,7 @@ impl<T: Transport> Eth<T> {
   }
 
   /// Signs a hash of given data
-  pub fn sign(&self, address: Address, data: Bytes) -> CallResult<H512, T::Out> {
+  pub fn sign(&self, address: Address, data: Bytes) -> CallResult<H520, T::Out> {
     let address = helpers::serialize(&address);
     let data = helpers::serialize(&data);
     CallResult::new(self.transport.execute("eth_sign", vec![address, data]))
@@ -652,7 +652,7 @@ mod tests {
     Eth:sign, 0x123, Bytes(vec![1, 2, 3, 4])
     =>
     "eth_sign", vec![r#""0x0000000000000000000000000000000000000123""#, r#""0x01020304""#];
-    Value::String("0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000123".into()) => 0x123
+    Value::String("0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000123".into()) => 0x123
   );
 
   rpc_test! (

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -15,7 +15,7 @@ pub use self::log::{Log, Filter, FilterBuilder};
 pub use self::transaction::{Transaction, Receipt as TransactionReceipt};
 pub use self::transaction_id::TransactionId;
 pub use self::transaction_request::{TransactionRequest, CallRequest, TransactionCondition};
-pub use self::uint::{H64, H128, H160, H256, H512, H2048, U64, U256};
+pub use self::uint::{H64, H128, H160, H256, H512, H520, H2048, U64, U256};
 pub use self::work::Work;
 
 /// Address

--- a/src/types/uint.rs
+++ b/src/types/uint.rs
@@ -248,6 +248,7 @@ impl_uint!(hash => H128, 16);
 impl_uint!(hash => H160, 20);
 impl_uint!(hash => H256, 32);
 impl_uint!(hash => H512, 64);
+impl_uint!(hash => H520, 65);
 impl_uint!(hash => H2048, 256);
 
 #[cfg(test)]


### PR DESCRIPTION
Since the signature data consists of "r (32 byte)", "s (32 byte)" and "v (1 byte)", I think that it is correct to receive at H520 instead of H512.