### PR TITLE
Fix inconsistency between features and extern

### DIFF
--- a/src/transports/mod.rs
+++ b/src/transports/mod.rs
@@ -22,7 +22,7 @@ pub use self::ipc::Ipc;
 mod shared;
 #[cfg(any(feature = "ipc", feature = "http"))]
 extern crate tokio_core;
-#[cfg(any(feature = "ipc", feature = "http"))]
+#[cfg(any(feature = "ipc"))]
 extern crate tokio_io;
 #[cfg(any(feature = "ipc", feature = "http"))]
 pub use self::shared::EventLoopHandle;


### PR DESCRIPTION
I think tokio_io is unnecessary for http.