### PR TITLE
Added Copy trait to BlockNumber.

### DIFF
--- a/src/types/block.rs
+++ b/src/types/block.rs
@@ -58,7 +58,7 @@ pub struct Block<TX> {
 }
 
 /// Block Number
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum BlockNumber {
   /// Latest block
   Latest,


### PR DESCRIPTION
I'd like to add a Copy trait to use BlockNumber like an Address.

```
fn test() {
    let (_eloop, transport) = Http::new("http://localhost:8545").unwrap();
    let rpc = Web3::new(&transport);
    let address = Address::from(1);
    let number = BlockNumber::from(1);
    let balance = rpc.eth().balance(address, Some(number));
    println!("{:?}", address);
    println!("{:?}", number);
}
```

```
error[E0382]: use of moved value: `number`
   --> src\test.rs:197:26
    |
195 |         let balance = rpc.eth().balance(address, Some(number));
    |                                                       ------ value moved here
196 |         println!("{:?}", address);
197 |         println!("{:?}", number);
    |                          ^^^^^^ value used here after move
    |
    = note: move occurs because `number` has type `web3::types::BlockNumber`, which does not implement the `Copy` trait
```