### PR TITLE
Fixed that CLOSE_WAIT connection remains for a while.

### DIFF
--- a/src/transports/http.rs
+++ b/src/transports/http.rs
@@ -110,6 +110,7 @@ impl Http {
     let mut req = hyper::client::Request::new(hyper::Method::Post, self.url.clone());
     req.headers_mut().set(hyper::header::ContentType::json());
     req.headers_mut().set(hyper::header::UserAgent::new("web3.rs"));
+    req.headers_mut().set(hyper::header::Connection::close());
     let len = request.len();
     // Don't send chunked request
     if len < MAX_SINGLE_CHUNK {


### PR DESCRIPTION
When accessing Parity, the problem that CLOSE_WAIT state connection remains for a while (about 2 minutes) is fixed.
This problem becomes more noticeable when access to Parity is repeated.