### PR TITLE
confirmation support for raw transactions

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -15,7 +15,7 @@ pub use self::web3::Web3 as Web3Api;
 use std::time::Duration;
 use futures::{IntoFuture};
 use {confirm, Transport, Error};
-use types::{U256, TransactionRequest};
+use types::{U256, Bytes, TransactionRequest};
 
 /// Common API for all namespaces
 pub trait Namespace<T: Transport>: Clone {
@@ -97,4 +97,16 @@ impl<T: Transport> Web3<T> {
   ) -> confirm::SendTransactionWithConfirmation<T> {
     confirm::send_transaction_with_confirmation(self.transport.clone(), tx, poll_interval, confirmations)
   }
+
+  /// Sends raw transaction and returns future resolved after transaction is confirmed
+  pub fn send_raw_transaction_with_confirmation(
+    &self,
+    tx: Bytes,
+    poll_interval: Duration,
+    confirmations: usize
+  ) -> confirm::SendTransactionWithConfirmation<T> {
+    confirm::send_raw_transaction_with_confirmation(self.transport.clone(), tx, poll_interval, confirmations)
+  }
+
 }
+


### PR DESCRIPTION
Added support for confirmation of raw transactions.

The underlying confirmation mechanism for regular transactions works fine for raw transactions too.  Added a new constructor and public function so that this functionality is now accessible.