### PR TITLE
Add proper return type for `eth_syncing`.

### DIFF
--- a/src/api/eth.rs
+++ b/src/api/eth.rs
@@ -6,7 +6,7 @@ use types::{
   Address, Block, BlockId, BlockNumber, Bytes, CallRequest,
   H64, H256, H520, Index,
   Transaction, TransactionId, TransactionReceipt, TransactionRequest,
-  U256, Work,
+  U256, Work, SyncState,
 };
 use {Transport};
 
@@ -301,9 +301,8 @@ impl<T: Transport> Eth<T> {
     CallResult::new(self.transport.execute("eth_submitWork", vec![nonce, pow_hash, mix_hash]))
   }
 
-  // TODO [ToDr] Proper type?
   /// Get syncing status
-  pub fn syncing(&self) -> CallResult<bool, T::Out> {
+  pub fn syncing(&self) -> CallResult<SyncState, T::Out> {
     CallResult::new(self.transport.execute("eth_syncing", vec![]))
   }
 }

--- a/src/api/eth.rs
+++ b/src/api/eth.rs
@@ -670,7 +670,12 @@ mod tests {
   );
 
   rpc_test! (
-    Eth:syncing => "eth_syncing";
+    Eth:syncing:syncing => "eth_syncing";
     json!({"startingBlock": "0x384","currentBlock": "0x386","highestBlock": "0x454"}) => SyncState::Syncing(SyncInfo { starting_block: 0x384.into(), current_block: 0x386.into(), highest_block: 0x454.into()})
   );
+
+  rpc_test! {
+    Eth:syncing:not_syncing => "eth_syncing";
+    Value::Bool(false) => SyncState::NotSyncing
+  }
 }

--- a/src/api/eth.rs
+++ b/src/api/eth.rs
@@ -316,7 +316,7 @@ mod tests {
     Block, BlockId, BlockNumber, Bytes,
     CallRequest, H256, Transaction, TransactionId,
     TransactionReceipt, TransactionRequest,
-    Work,
+    Work, SyncState, SyncInfo,
   };
   use rpc::Value;
 
@@ -671,6 +671,6 @@ mod tests {
 
   rpc_test! (
     Eth:syncing => "eth_syncing";
-    Value::Bool(true) => true
+    json!({"startingBlock": "0x384","currentBlock": "0x386","highestBlock": "0x454"}) => SyncState::Syncing(SyncInfo { starting_block: 0x384.into(), current_block: 0x386.into(), highest_block: 0x454.into()})
   );
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -3,6 +3,7 @@
 mod block;
 mod bytes;
 mod log;
+mod sync_state;
 mod transaction;
 mod transaction_id;
 mod transaction_request;
@@ -12,6 +13,7 @@ mod work;
 pub use self::block::{Block, BlockId, BlockNumber};
 pub use self::bytes::Bytes;
 pub use self::log::{Log, Filter, FilterBuilder};
+pub use self::sync_state::{SyncState,SyncInfo};
 pub use self::transaction::{Transaction, Receipt as TransactionReceipt};
 pub use self::transaction_id::TransactionId;
 pub use self::transaction_request::{TransactionRequest, CallRequest, TransactionCondition};

--- a/src/types/sync_state.rs
+++ b/src/types/sync_state.rs
@@ -2,6 +2,7 @@ use serde::de::{Deserialize,Deserializer,Error};
 use serde::ser::{Serialize,Serializer};
 use types::U256;
 
+
 /// Information about current blockchain syncing operations.
 #[derive(Debug,Clone,PartialEq,Serialize,Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -26,7 +27,6 @@ pub enum SyncState {
     /// Blockchain is not syncing.
     NotSyncing
 }
-
 
 
 // The `eth_syncing` method returns either `false` or an instance of the sync info object.
@@ -69,6 +69,3 @@ enum Either<A,B> {
     A(A),
     B(B)
 }
-
-
-

--- a/src/types/sync_state.rs
+++ b/src/types/sync_state.rs
@@ -1,0 +1,74 @@
+use serde::de::{Deserialize,Deserializer,Error};
+use serde::ser::{Serialize,Serializer};
+use types::U256;
+
+/// Information about current blockchain syncing operations.
+#[derive(Debug,Clone,Serialize,Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncInfo {
+    /// The block at which import began.
+    pub starting_block: U256,
+
+    /// The highest currently synced block.
+    pub current_block: U256,
+    
+    /// The estimated highest block.
+    pub highest_block: U256
+}
+
+
+/// The current state of blockchain syncing operations.
+#[derive(Debug,Clone)]
+pub enum SyncState {
+    /// Blockchain is syncing.
+    Syncing(SyncInfo),
+
+    /// Blockchain is not syncing.
+    NotSyncing
+}
+
+
+
+// The `eth_syncing` method returns either `false` or an instance of the sync info object.
+// This doesn't play particularly well with the features exposed by `serde_derive`,
+// so we use the custom impls below to ensure proper behavior.
+
+impl<'de> Deserialize<'de> for SyncState {
+
+    fn deserialize<D>(deserializer: D) -> Result<Self,D::Error> where D: Deserializer<'de> {
+        let either: Either<SyncInfo,bool> = Deserialize::deserialize(deserializer)?;
+        match either {
+            Either::A(info) => Ok(SyncState::Syncing(info)),
+            Either::B(boolian) => {
+                if !boolian {
+                    Ok(SyncState::NotSyncing)
+                } else {
+                    Err(D::Error::custom("expected object or `false`, got `true`"))
+                }
+            }
+        }
+    }
+}
+
+
+impl Serialize for SyncState {
+
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok,S::Error> where S: Serializer {
+        match *self {
+            SyncState::Syncing(ref info) => info.serialize(serializer),
+            SyncState::NotSyncing => false.serialize(serializer)
+        }
+    }
+}
+
+
+/// implementation detail for sync state deserialization
+#[derive(Debug,Serialize,Deserialize)]
+#[serde(untagged)]
+enum Either<A,B> {
+    A(A),
+    B(B)
+}
+
+
+

--- a/src/types/sync_state.rs
+++ b/src/types/sync_state.rs
@@ -3,7 +3,7 @@ use serde::ser::{Serialize,Serializer};
 use types::U256;
 
 /// Information about current blockchain syncing operations.
-#[derive(Debug,Clone,Serialize,Deserialize)]
+#[derive(Debug,Clone,PartialEq,Serialize,Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SyncInfo {
     /// The block at which import began.
@@ -18,7 +18,7 @@ pub struct SyncInfo {
 
 
 /// The current state of blockchain syncing operations.
-#[derive(Debug,Clone)]
+#[derive(Debug,Clone,PartialEq)]
 pub enum SyncState {
     /// Blockchain is syncing.
     Syncing(SyncInfo),


### PR DESCRIPTION
Added the expected return type for `eth_syncing` as per the ethereum jsonrpc spec.  Tested against syncing and non-syncing parity node.  This is a breaking api change, but I believe this (or something like it) is necessary pre 1.0, since the current return value (bool) is definitely insufficient.  Cheers.

*edit*:  Forgot that I horribly mangled the tests.  Fixed.