### PR TITLE
fix peer count return type

### DIFF
--- a/src/api/net.rs
+++ b/src/api/net.rs
@@ -2,6 +2,7 @@
 
 use api::Namespace;
 use helpers::CallResult;
+use types::U256;
 
 use {Transport};
 
@@ -30,7 +31,7 @@ impl<T: Transport> Net<T> {
   }
 
   /// Returns number of peers connected to node.
-  pub fn peer_count(&self) -> CallResult<String, T::Out> {
+  pub fn peer_count(&self) -> CallResult<U256, T::Out> {
     CallResult::new(self.transport.execute("net_peerCount", vec![]))
   }
 
@@ -46,6 +47,7 @@ mod tests {
 
   use api::Namespace;
   use rpc::Value;
+  use types::U256;
 
   use super::Net;
 
@@ -56,7 +58,7 @@ mod tests {
 
   rpc_test! (
     Net:peer_count => "net_peerCount";
-    Value::String("Test123".into()) => "Test123"
+    Value::String("0x123".into()) => U256::from(0x123)
   );
 
   rpc_test! (


### PR DESCRIPTION
The `Net::peer_count` method was returning a string.  Changed to `U256` to reflect expected return type as per spec.  Updated unit tests in crate and ran sanity checks against local parity node.

@tomusdrw I'll probably have a few more of these over the next couple weeks.  In the process of integrating `web3` into a number of components of a mid size codebase.  Let me know if you would prefer reviewing a batch PR.  Otherwise I'll be keeping it per-feature.  Cheers.