### PR TITLE
Implement tokenization of tuples of up to length 16 (#94).

### DIFF
--- a/src/contract/tokens.rs
+++ b/src/contract/tokens.rs
@@ -90,6 +90,17 @@ impl_tokens!(A:0, B:1, );
 impl_tokens!(A:0, B:1, C:2, );
 impl_tokens!(A:0, B:1, C:2, D:3, );
 impl_tokens!(A:0, B:1, C:2, D:3, E:4, );
+impl_tokens!(A:0, B:1, C:2, D:3, E:4, F:5, );
+impl_tokens!(A:0, B:1, C:2, D:3, E:4, F:5, G:6, );
+impl_tokens!(A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, );
+impl_tokens!(A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, );
+impl_tokens!(A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, );
+impl_tokens!(A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, K:10, );
+impl_tokens!(A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, K:10, L:11, );
+impl_tokens!(A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, K:10, L:11, M:12, );
+impl_tokens!(A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, K:10, L:11, M:12, N:13, );
+impl_tokens!(A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, K:10, L:11, M:12, N:13, O:14, );
+impl_tokens!(A:0, B:1, C:2, D:3, E:4, F:5, G:6, H:7, I:8, J:9, K:10, L:11, M:12, N:13, O:14, P:15, );
 
 /// Simplified output type for single value.
 pub trait Tokenizable {


### PR DESCRIPTION
This allows you to call EVM functions with up to 16 arguments.