### PR TITLE
Add WebSocket transport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,6 @@ default = ["http", "ipc", "ws"]
 # TODO [ToDr] move transports to separate crates
 http = ["hyper", "tokio-core"]
 ipc = ["tokio-uds", "tokio-core", "tokio-io"]
-ws = ["websocket"]
+ws = ["tokio-core", "websocket"]
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ hyper = { version = "0.11", optional = true }
 tokio-core = { version = "0.1", optional = true }
 tokio-io = { version = "0.1", optional = true }
 tokio-uds = { version = "0.1", optional = true }
+websocket = { version = "0.20", optional = true }
 
 [dev-dependencies]
 # For examples
@@ -36,9 +37,10 @@ tokio-core = "0.1"
 rustc-hex = "1.0"
 
 [features]
-default = ["http", "ipc"]
+default = ["http", "ipc", "ws"]
 # TODO [ToDr] move transports to separate crates
 http = ["hyper", "tokio-core"]
 ipc = ["tokio-uds", "tokio-core", "tokio-io"]
+ws = ["websocket"]
 
 [workspace]

--- a/examples/simple_ws.rs
+++ b/examples/simple_ws.rs
@@ -1,0 +1,11 @@
+extern crate web3;
+
+use web3::futures::Future;
+
+fn main() {
+  let (_eloop, ws) = web3::transports::WebSocket::new("ws://localhost:8546").unwrap();
+  let web3 = web3::Web3::new(ws);
+  let accounts = web3.eth().accounts().wait().unwrap();
+
+  println!("Accounts: {:?}", accounts);
+}

--- a/src/transports/mod.rs
+++ b/src/transports/mod.rs
@@ -1,6 +1,6 @@
 //! Supported Ethereum JSON-RPC transports.
 
-use {Error};
+use Error;
 
 /// RPC Result.
 pub type Result<T> = ::std::result::Result<T, Error>;
@@ -18,11 +18,16 @@ pub mod ipc;
 #[cfg(feature = "ipc")]
 pub use self::ipc::Ipc;
 
-#[cfg(any(feature = "ipc", feature = "http"))]
+#[cfg(feature = "ws")]
+pub mod ws;
+#[cfg(feature = "ws")]
+pub use self::ws::WebSocket;
+
+#[cfg(any(feature = "ipc", feature = "http", feature = "ws"))]
 mod shared;
-#[cfg(any(feature = "ipc", feature = "http"))]
+#[cfg(any(feature = "ipc", feature = "http", feature = "ws"))]
 extern crate tokio_core;
 #[cfg(any(feature = "ipc"))]
 extern crate tokio_io;
-#[cfg(any(feature = "ipc", feature = "http"))]
+#[cfg(any(feature = "ipc", feature = "http", feature = "ws"))]
 pub use self::shared::EventLoopHandle;

--- a/src/transports/ws.rs
+++ b/src/transports/ws.rs
@@ -64,7 +64,6 @@ impl WebSocket {
       let write_sender_ = write_sender.clone();
 
       ClientBuilder::from_url(&url)
-        .add_protocol("web3.rs")
         .async_connect(None, handle)
         .from_err::<Error>()
         .map(|(duplex, _)| duplex.split())

--- a/src/transports/ws.rs
+++ b/src/transports/ws.rs
@@ -1,0 +1,258 @@
+//! WebSocket Transport
+
+extern crate websocket;
+
+use std::collections::BTreeMap;
+use std::sync::{atomic, Arc};
+
+use futures::sync::{mpsc, oneshot};
+use futures::{self, Future, Sink, Stream};
+use helpers;
+use parking_lot::Mutex;
+use rpc;
+use self::websocket::{ClientBuilder, OwnedMessage};
+use self::websocket::url::Url;
+use transports::Result;
+use transports::shared::{EventLoopHandle, Response};
+use transports::tokio_core::reactor;
+use {BatchTransport, Error, ErrorKind, RequestId, Transport};
+
+impl From<websocket::WebSocketError> for Error {
+  fn from(err: websocket::WebSocketError) -> Self {
+    ErrorKind::Transport(format!("{:?}", err)).into()
+  }
+}
+
+impl From<websocket::client::ParseError> for Error {
+  fn from(err: websocket::client::ParseError) -> Self {
+    ErrorKind::Transport(format!("{:?}", err)).into()
+  }
+}
+
+type Pending = oneshot::Sender<Result<Vec<Result<rpc::Value>>>>;
+
+/// A future representing pending WebSocket request, resolves to a response.
+pub type WsTask<F> = Response<F, Vec<Result<rpc::Value>>>;
+
+/// WebSocket transport
+#[derive(Debug, Clone)]
+pub struct WebSocket {
+  id: Arc<atomic::AtomicUsize>,
+  url: Url,
+  pending: Arc<Mutex<BTreeMap<RequestId, Pending>>>,
+  write_sender: mpsc::UnboundedSender<OwnedMessage>,
+}
+
+impl WebSocket {
+  /// Create new WebSocket transport with separate event loop.
+  /// NOTE: Dropping event loop handle will stop the transport layer!
+  pub fn new(url: &str) -> Result<(EventLoopHandle, Self)> {
+    let url = url.to_owned();
+    EventLoopHandle::spawn(move |handle| Self::with_event_loop(&url, &handle).map_err(Into::into))
+  }
+
+  /// Create new WebSocket transport within existing Event Loop.
+  pub fn with_event_loop(url: &str, handle: &reactor::Handle) -> Result<Self> {
+    trace!("Connecting to: {:?}", url);
+
+    let url: Url = url.parse()?;
+    let (write_sender, write_receiver) = mpsc::unbounded();
+    let pending: Arc<Mutex<BTreeMap<RequestId, Pending>>> = Arc::new(Mutex::new(BTreeMap::new()));
+
+    let ws_future = {
+      let pending_ = pending.clone();
+      let write_sender_ = write_sender.clone();
+
+      ClientBuilder::from_url(&url)
+        .add_protocol("web3.rs")
+        .async_connect(None, handle)
+        .from_err::<Error>()
+        .map(|(duplex, _)| duplex.split())
+        .and_then(move |(sink, stream)| {
+          let reader = stream
+            .for_each(move |message| {
+              trace!("Message received: {:?}", message);
+
+              match message {
+                OwnedMessage::Close(e) => write_sender_
+                  .unbounded_send(OwnedMessage::Close(e))
+                  .map_err(|_| websocket::WebSocketError::NoDataAvailable),
+                OwnedMessage::Ping(d) => write_sender_
+                  .unbounded_send(OwnedMessage::Pong(d))
+                  .map_err(|_| websocket::WebSocketError::NoDataAvailable),
+                OwnedMessage::Text(t) => {
+                  let response = helpers::to_response_from_slice(t.as_bytes());
+                  let outputs = match response {
+                    Ok(rpc::Response::Single(output)) => vec![output],
+                    Ok(rpc::Response::Batch(outputs)) => outputs,
+                    _ => vec![],
+                  };
+
+                  let id = match outputs.get(0) {
+                    Some(&rpc::Output::Success(ref success)) => success.id.clone(),
+                    Some(&rpc::Output::Failure(ref failure)) => failure.id.clone(),
+                    None => rpc::Id::Num(0),
+                  };
+
+                  if let rpc::Id::Num(num) = id {
+                    if let Some(request) = pending_.lock().remove(&(num as usize)) {
+                      trace!("Responding to (id: {:?}) with {:?}", num, outputs);
+                      if let Err(err) = request.send(helpers::to_results_from_outputs(outputs)) {
+                        warn!("Sending a response to deallocated channel: {:?}", err);
+                      }
+                    } else {
+                      warn!("Got response for unknown request (id: {:?})", num);
+                    }
+                  } else {
+                    warn!("Got unsupported response (id: {:?})", id);
+                  }
+
+                  Ok(())
+                }
+                _ => Ok(()),
+              }
+            })
+            .from_err();
+
+          let writer = sink
+            .sink_from_err()
+            .send_all(write_receiver.map_err(|_| websocket::WebSocketError::NoDataAvailable))
+            .map(|_| ());
+
+          reader.join(writer)
+        })
+    };
+
+    handle.spawn(ws_future.map(|_| ()).map_err(|err| {
+      error!("WebSocketError: {:?}", err);
+    }));
+
+    Ok(Self {
+      id: Default::default(),
+      url: url,
+      write_sender,
+      pending,
+    })
+  }
+
+  fn send_request<F, O>(&self, id: RequestId, request: rpc::Request, extract: F) -> WsTask<F>
+  where
+    F: Fn(Vec<Result<rpc::Value>>) -> O,
+  {
+    let request = helpers::to_string(&request);
+    debug!("[{}] Calling: {}", id, request);
+    let (tx, rx) = futures::oneshot();
+    self.pending.lock().insert(id, tx);
+
+    let result = self
+      .write_sender
+      .unbounded_send(OwnedMessage::Text(request))
+      .map_err(|_| websocket::WebSocketError::NoDataAvailable.into());
+
+    Response::new(id, result, rx, extract)
+  }
+}
+
+impl Transport for WebSocket {
+  type Out = WsTask<fn(Vec<Result<rpc::Value>>) -> Result<rpc::Value>>;
+
+  fn prepare(&self, method: &str, params: Vec<rpc::Value>) -> (RequestId, rpc::Call) {
+    let id = self.id.fetch_add(1, atomic::Ordering::AcqRel);
+    let request = helpers::build_request(id, method, params);
+
+    (id, request)
+  }
+
+  fn send(&self, id: RequestId, request: rpc::Call) -> Self::Out {
+    self.send_request(id, rpc::Request::Single(request), |response| match response
+      .into_iter()
+      .next()
+    {
+      Some(res) => res,
+      None => Err(ErrorKind::InvalidResponse("Expected single, got batch.".into()).into()),
+    })
+  }
+}
+
+impl BatchTransport for WebSocket {
+  type Batch = WsTask<fn(Vec<Result<rpc::Value>>) -> Result<Vec<Result<rpc::Value>>>>;
+
+  fn send_batch<T>(&self, requests: T) -> Self::Batch
+  where
+    T: IntoIterator<Item = (RequestId, rpc::Call)>,
+  {
+    let mut it = requests.into_iter();
+    let (id, first) = it.next()
+      .map(|x| (x.0, Some(x.1)))
+      .unwrap_or_else(|| (0, None));
+    let requests = first.into_iter().chain(it.map(|x| x.1)).collect();
+    self.send_request(id, rpc::Request::Batch(requests), Ok)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  extern crate tokio_core;
+  extern crate websocket;
+
+  use super::WebSocket;
+  use futures::{Future, Sink, Stream};
+  use rpc;
+  use self::websocket::async::Server;
+  use self::websocket::message::OwnedMessage;
+  use self::websocket::server::InvalidConnection;
+  use Transport;
+
+  #[test]
+  fn should_send_a_request() {
+    // given
+    let mut eloop = tokio_core::reactor::Core::new().unwrap();
+    let handle = eloop.handle();
+    let server = Server::bind("localhost:3000", &handle).unwrap();
+    let f = {
+      let handle_ = handle.clone();
+      server
+        .incoming()
+        .take(1)
+        .map_err(|InvalidConnection { error, .. }| error)
+        .for_each(move |(upgrade, addr)| {
+          trace!("Got a connection from {}", addr);
+          let f = upgrade.use_protocol("web3.rs").accept().and_then(|(s, _)| {
+            let (sink, stream) = s.split();
+
+            stream
+              .take_while(|m| Ok(!m.is_close()))
+              .filter_map(|m| match m {
+                OwnedMessage::Ping(p) => Some(OwnedMessage::Pong(p)),
+                OwnedMessage::Pong(_) => None,
+                OwnedMessage::Text(t) => {
+                  assert_eq!(
+                    t,
+                    r#"{"jsonrpc":"2.0","method":"eth_accounts","params":["1"],"id":0}"#
+                  );
+                  Some(OwnedMessage::Text(
+                    r#"{"jsonrpc":"2.0","id":0,"result":"x"}"#.to_owned(),
+                  ))
+                }
+                _ => None,
+              })
+              .forward(sink)
+              .and_then(|(_, sink)| sink.send(OwnedMessage::Close(None)))
+          });
+
+          handle_.spawn(f.map(|_| ()).map_err(|_| ()));
+
+          Ok(())
+        })
+    };
+    handle.spawn(f.map_err(|_| ()));
+
+    let ws = WebSocket::with_event_loop("ws://localhost:3000", &handle).unwrap();
+
+    // when
+    let res = ws.execute("eth_accounts", vec![rpc::Value::String("1".into())]);
+
+    // then
+    assert_eq!(eloop.run(res), Ok(rpc::Value::String("x".into())));
+  }
+}

--- a/src/transports/ws.rs
+++ b/src/transports/ws.rs
@@ -128,7 +128,7 @@ impl WebSocket {
     }));
 
     Ok(Self {
-      id: Default::default(),
+      id: Arc::new(atomic::AtomicUsize::new(1)),
       url: url,
       write_sender,
       pending,
@@ -228,10 +228,10 @@ mod tests {
                 OwnedMessage::Text(t) => {
                   assert_eq!(
                     t,
-                    r#"{"jsonrpc":"2.0","method":"eth_accounts","params":["1"],"id":0}"#
+                    r#"{"jsonrpc":"2.0","method":"eth_accounts","params":["1"],"id":1}"#
                   );
                   Some(OwnedMessage::Text(
-                    r#"{"jsonrpc":"2.0","id":0,"result":"x"}"#.to_owned(),
+                    r#"{"jsonrpc":"2.0","id":1,"result":"x"}"#.to_owned(),
                   ))
                 }
                 _ => None,


### PR DESCRIPTION
Addresses #14 , gated behind "ws" feature (did add to default features however), adds https://crates.io/crates/websocket as a dependency.

Tested basic RPC functionality against geth 1.8.2 with the websocket endpoint enabled.