### PR TITLE
Return SyncState from eth_subscribe(syncing)

### DIFF
--- a/src/api/eth_subscribe.rs
+++ b/src/api/eth_subscribe.rs
@@ -5,10 +5,9 @@ use std::marker::PhantomData;
 use api::Namespace;
 use futures::{Async, Future, Poll, Stream};
 use helpers::{self, CallResult};
-use rpc;
 use serde;
 use serde_json;
-use types::{BlockHeader, Filter, H256, Log};
+use types::{BlockHeader, Filter, H256, Log, SyncState};
 use {DuplexTransport, Error};
 
 /// `Eth` namespace, subscriptions
@@ -165,7 +164,7 @@ impl<T: DuplexTransport> EthSubscribe<T> {
     }
 
     /// Create a sync status subscription
-    pub fn subscribe_syncing(&self) -> SubscriptionResult<T, rpc::Value> {
+    pub fn subscribe_syncing(&self) -> SubscriptionResult<T, SyncState> {
         let subscription = helpers::serialize(&&"syncing");
         let id_future = CallResult::new(self.transport.execute("eth_subscribe", vec![subscription]));
         SubscriptionResult::new(self.transport().clone(), id_future)

--- a/src/types/sync_state.rs
+++ b/src/types/sync_state.rs
@@ -1,4 +1,4 @@
-use serde::de::{Deserialize, Deserializer, Error};
+use serde::de::{Deserialize, DeserializeOwned, Deserializer, Error};
 use serde::ser::{Serialize, Serializer};
 use types::U256;
 
@@ -26,19 +26,68 @@ pub enum SyncState {
     NotSyncing,
 }
 
+// `eth_subscribe(syncing)` returns a SyncInfo object with a different format
+fn deserialize_subscription<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: DeserializeOwned,
+    D: Deserializer<'de>,
+{
+    use serde_json::Value;
+    use std::collections::BTreeMap;
+
+    let map = BTreeMap::<String, Value>::deserialize(deserializer)?;
+    let renamed = map.into_iter()
+        .map(|(k, v)| {
+            let mut cs = k.chars();
+            let nk = match cs.next() {
+                None => String::new(),
+                Some(c) => c.to_lowercase().collect::<String>() + cs.as_str(),
+            };
+            let nv = Value::String(format!("0x{:x}", v.as_u64().unwrap_or(0u64)));
+
+            (nk, nv)
+        })
+        .collect();
+    T::deserialize(Value::Object(renamed)).map_err(Error::custom)
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct SubscriptionSyncInfo {
+    pub syncing: bool,
+
+    #[serde(deserialize_with = "deserialize_subscription")]
+    pub status: Option<SyncInfo>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+enum SyncStateVariants {
+    Subscription(SubscriptionSyncInfo),
+    Rpc(SyncInfo),
+    Boolean(bool),
+}
+
 // The `eth_syncing` method returns either `false` or an instance of the sync info object.
 // This doesn't play particularly well with the features exposed by `serde_derive`,
 // so we use the custom impls below to ensure proper behavior.
-
 impl<'de> Deserialize<'de> for SyncState {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let either: Either<SyncInfo, bool> = Deserialize::deserialize(deserializer)?;
-        match either {
-            Either::A(info) => Ok(SyncState::Syncing(info)),
-            Either::B(boolian) => {
+        let v: SyncStateVariants = Deserialize::deserialize(deserializer)?;
+        match v {
+            SyncStateVariants::Subscription(info) => {
+                if !info.syncing {
+                    Ok(SyncState::NotSyncing)
+                } else if let Some(status) = info.status {
+                    Ok(SyncState::Syncing(status))
+                } else {
+                    Err(D::Error::custom("syncing is `true` but no status reported"))
+                }
+            }
+            SyncStateVariants::Rpc(info) => Ok(SyncState::Syncing(info)),
+            SyncStateVariants::Boolean(boolian) => {
                 if !boolian {
                     Ok(SyncState::NotSyncing)
                 } else {
@@ -59,12 +108,4 @@ impl Serialize for SyncState {
             SyncState::NotSyncing => false.serialize(serializer),
         }
     }
-}
-
-/// implementation detail for sync state deserialization
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(untagged)]
-enum Either<A, B> {
-    A(A),
-    B(B),
 }


### PR DESCRIPTION
Previously returned a `rpc::Value` as the format is different than returned from `eth_syncing`, changed the deserialization of `types::SyncState` to support this as well.

Tested against geth, parity as of 1.10.0 apparently doesn't support this subscription type.