### PR TITLE
Set Block seal_fields attribute to an empty vector if missing(#135)

### DIFF
--- a/src/types/block.rs
+++ b/src/types/block.rs
@@ -90,7 +90,7 @@ pub struct Block<TX> {
     #[serde(rename = "totalDifficulty")]
     pub total_difficulty: U256,
     /// Seal fields
-    #[serde(rename = "sealFields")]
+    #[serde(default, rename = "sealFields")]
     pub seal_fields: Vec<Bytes>,
     /// Uncles' hashes
     pub uncles: Vec<H256>,


### PR DESCRIPTION
This fixes #135. By using `#[serde(default, ...)]` the value of `seal_fields` is set to an empty vector if it is not present in a block.