### PR TITLE
Fix shared mutability in TestTransport

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -103,7 +103,7 @@ pub mod tests {
     pub struct TestTransport {
         asserted: usize,
         requests: Rc<RefCell<Vec<(String, Vec<rpc::Value>)>>>,
-        response: Rc<RefCell<VecDeque<rpc::Value>>>,
+        responses: Rc<RefCell<VecDeque<rpc::Value>>>,
     }
 
     impl Transport for TestTransport {
@@ -116,7 +116,7 @@ pub mod tests {
         }
 
         fn send(&self, id: RequestId, request: rpc::Call) -> Result<rpc::Value> {
-            match self.response.borrow_mut().pop_front() {
+            match self.responses.borrow_mut().pop_front() {
                 Some(response) => Box::new(futures::finished(response)),
                 None => {
                     println!("Unexpected request (id: {:?}): {:?}", id, request);
@@ -128,11 +128,11 @@ pub mod tests {
 
     impl TestTransport {
         pub fn set_response(&mut self, value: rpc::Value) {
-            *self.response.borrow_mut() = vec![value].into();
+            *self.responses.borrow_mut() = vec![value].into();
         }
 
         pub fn add_response(&mut self, value: rpc::Value) {
-            self.response.borrow_mut().push_back(value);
+            self.responses.borrow_mut().push_back(value);
         }
 
         pub fn assert_request(&mut self, method: &str, params: &[String]) {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -94,6 +94,7 @@ pub mod tests {
     use serde_json;
     use std::cell::RefCell;
     use std::collections::VecDeque;
+    use std::rc::Rc;
     use futures;
     use rpc;
     use {ErrorKind, RequestId, Result, Transport};
@@ -101,8 +102,8 @@ pub mod tests {
     #[derive(Debug, Default, Clone)]
     pub struct TestTransport {
         asserted: usize,
-        requests: RefCell<Vec<(String, Vec<rpc::Value>)>>,
-        response: RefCell<VecDeque<rpc::Value>>,
+        requests: Rc<RefCell<Vec<(String, Vec<rpc::Value>)>>>,
+        response: Rc<RefCell<VecDeque<rpc::Value>>>,
     }
 
     impl Transport for TestTransport {


### PR DESCRIPTION
This fixes #137, using the solution described in the issue (and also in the commit message).