### PR TITLE
Fix 0.3.1 compile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 
 [dependencies]
 arrayvec = "0.4"
-error-chain = "0.11"
+error-chain = "0.12"
 ethabi = "5.1"
-ethereum-types = "0.3"
+ethereum-types = "0.4"
 futures = "0.1"
 jsonrpc-core = "8.0.1"
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web3"
-version = "0.3.1"
+version = "0.4.0"
 description = "Ethereum JSON-RPC client."
 homepage = "https://github.com/tomusdrw/rust-web3"
 repository = "https://github.com/tomusdrw/rust-web3"

--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -320,7 +320,7 @@ mod tests {
     fn should_estimate_gas_usage() {
         // given
         let mut transport = TestTransport::default();
-        transport.set_response(rpc::Value::String(format!("{:?}", U256::from(5))));
+        transport.set_response(rpc::Value::String(format!("{:#x}", U256::from(5))));
 
         let result = {
             let token = contract(&transport);

--- a/src/types/uint.rs
+++ b/src/types/uint.rs
@@ -1,4 +1,4 @@
-pub use ethereum_types::{Bloom as H2048, H1024, H128, H160, H256, H512, H520, H64, U128, U256, U64};
+pub use ethereum_types::{Bloom as H2048, H128, H160, H256, H512, H520, H64, U128, U256, U64};
 
 #[cfg(test)]
 mod tests {
@@ -43,10 +43,10 @@ mod tests {
         let d = U256::from(10000);
 
         // Debug
-        assert_eq!(&format!("{:?}", a), "0xa00010f00");
-        assert_eq!(&format!("{:?}", b), "0x3ff");
-        assert_eq!(&format!("{:?}", c), "0x0");
-        assert_eq!(&format!("{:?}", d), "0x2710");
+        assert_eq!(&format!("{:?}", a), "42949742336");
+        assert_eq!(&format!("{:?}", b), "1023");
+        assert_eq!(&format!("{:?}", c), "0");
+        assert_eq!(&format!("{:?}", d), "10000");
 
         // Display
         assert_eq!(&format!("{}", a), "42949742336");
@@ -59,6 +59,12 @@ mod tests {
         assert_eq!(&format!("{:x}", b), "3ff");
         assert_eq!(&format!("{:x}", c), "0");
         assert_eq!(&format!("{:x}", d), "2710");
+
+        // Prefixed Lowerhex
+        assert_eq!(&format!("{:#x}", a), "0xa00010f00");
+        assert_eq!(&format!("{:#x}", b), "0x3ff");
+        assert_eq!(&format!("{:#x}", c), "0x0");
+        assert_eq!(&format!("{:#x}", d), "0x2710");
     }
 
     #[test]


### PR DESCRIPTION
fixes #153 
Bump error-chain to 0.12
Bump ethereum-types to 0.4
version bumps effects hex-0x-prefixed display: from {:?} to {:#x}
fix affected tests by version change
  - types::uint::tests::should_display_correctly
  - contract::tests::should_estimate_gas_usage

type H1024 no longer exists in ethereum_types 0.4.0, and this commit removes it from types/uint.rs