### PR TITLE
Ensure that 'to' = None when it is a contract creation transaction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,5 +46,6 @@ http = ["hyper", "tokio-core"]
 ipc = ["tokio-uds", "tokio-core", "tokio-io"]
 ws = ["tokio-core", "websocket"]
 tls = ["hyper-tls", "native-tls"]
+account-zero = []
 
 [workspace]

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -1,4 +1,6 @@
 use types::{Bytes, H160, H256, Index, Log, U256, U64};
+use serde::{de, export::fmt, Deserializer};
+use serde_json;
 
 /// Description of a Transaction, pending or in the chain.
 #[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
@@ -19,6 +21,7 @@ pub struct Transaction {
     /// Sender
     pub from: H160,
     /// Recipient (None when contract creation)
+    #[serde(deserialize_with = "deserialize_to")]
     pub to: Option<H160>,
     /// Transfered value
     pub value: U256,
@@ -61,10 +64,43 @@ pub struct Receipt {
     pub status: Option<U64>,
 }
 
+
+fn deserialize_to<'de, D>(deserializer: D) -> Result<Option<H160>, D::Error>
+    where
+        D: Deserializer<'de>,
+{
+    struct Visitor;
+
+    impl<'de> de::Visitor<'de> for Visitor {
+        type Value = Option<H160>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("0x-prefixed hex string")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Option<H160>, E>
+            where
+                E: de::Error,
+        {
+            match value {
+                "0x0" | "0x0000000000000000000000000000000000000000" =>
+                    Ok(None),
+                value => {
+                    let result = serde_json::from_str(&format!("{:?}", value)).map_err(E::custom)?;
+                    Ok(Some(result))
+                },
+            }
+        }
+    }
+    deserializer.deserialize_str(Visitor)
+}
+
+
 #[cfg(test)]
 mod tests {
     use serde_json;
     use super::Receipt;
+    use super::Transaction;
 
     #[test]
     fn test_deserialize_receipt() {
@@ -90,5 +126,45 @@ mod tests {
     }"#;
 
         let _receipt: Receipt = serde_json::from_str(receipt_str).unwrap();
+    }
+
+    #[test]
+    fn should_deserialize_transaction() {
+        let transaction_str = r#"{
+                "hash": "0x53b9c569584541f8bd1c874ea6409acc45fefb249af8e58b26936b54a0da140b",
+                "nonce": "0x0",
+                "blockHash": "0x0ae7d24c16f6e8cd16a732bc72e8b367e775e2be7cd1af128c58478038d28388",
+                "blockNumber": "0x02",
+                "transactionIndex": "0x00",
+                "from": "0x96984c3e77f38ed01d1c3d98f4bd7c8b11d51d7e",
+
+"to": "0xa00f2cac7bad9285ecfd59e8860f5b2d8622e099",
+
+                "value": "0x0",
+                "gas": "0x100000",
+                "gasPrice": "0x01",
+                "input": "0xf5c4e30096e501347bcec8adb459eb0b8703af22dbda7382a04fea75110fa812"
+            }"#;
+
+        let _transaction: Transaction = serde_json::from_str(transaction_str).unwrap();
+    }
+
+    #[test]
+    fn should_deserialize_transaction_with_to_address_zero() {
+        let transaction_str = r#"{
+                "hash": "0xecee5907db9bb4b2e8c48fded723174e386b74a8fc8b74f17e6cace1655caefe",
+                "nonce": "0x0",
+                "blockHash": "0xf04cac6878b58993abe986c15acf00f07887b9baf9bfd6d5b5097d52455c4ee5",
+                "blockNumber": "0x01",
+                "transactionIndex": "0x00",
+                "from": "0x147ba99ef89c152f8004e91999fee87bda6cbc3e",
+                "to": "0x0000000000000000000000000000000000000000",
+                "value": "0x8ac7230489e80000",
+                "gas": "0x0170c0",
+                "gasPrice": "0x77359400",
+                "input": "0x426000526063601b53610082600561001b01602039610082601bf36350000005602060006000376020602160206000600060026048f17f49195bfd5b5b53f1a30135c8eabffbefa39be1dde06aa43736b0c5ca570654d560215114166054574203630000a8c010606b5760006000f35b733853005576eeca2ba7ec579ce04c1ce2f4cd162eff5b7350358ea110e2ae0e509cd0dee177064c58e4a1e5ff"
+            }"#;
+
+        let _transaction: Transaction = serde_json::from_str(transaction_str).unwrap();
     }
 }


### PR DESCRIPTION
Good day,

The documentation on the Transaction struct says that `Transaction.to` is "Recipient (None when contract creation)".

However, in web3 json response, the `to` field actually contains address zero (used for contract deployments), hence this field is not always `None`. Tested with ganache & infura.

This change is to ensure that if the `to` field is present and it is zero address, then `None` is used.

Let me know if you prefer me to implement this in a different manner, I could not think of something more elegant.