### PR TITLE
make blockNumber and blockHash optional in TransactionReceipt

### DIFF
--- a/src/confirm.rs
+++ b/src/confirm.rs
@@ -171,7 +171,7 @@ impl<T: Transport> Future for TransactionReceiptBlockNumber<T> {
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let receipt = try_ready!(self.future.poll());
-        Ok(receipt.map(|receipt| receipt.block_number).into())
+        Ok(receipt.and_then(|receipt| receipt.block_number).into())
     }
 }
 
@@ -332,8 +332,8 @@ mod tests {
         let transaction_receipt = TransactionReceipt {
             transaction_hash: 0.into(),
             transaction_index: 0.into(),
-            block_hash: 0.into(),
-            block_number: 2.into(),
+            block_hash: Some(0.into()),
+            block_number: Some(2.into()),
             cumulative_gas_used: 0.into(),
             gas_used: 0.into(),
             contract_address: None,

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -42,10 +42,10 @@ pub struct Receipt {
     pub transaction_index: Index,
     /// Hash of the block this transaction was included within.
     #[serde(rename = "blockHash")]
-    pub block_hash: H256,
+    pub block_hash: Option<H256>,
     /// Number of the block this transaction was included within.
     #[serde(rename = "blockNumber")]
-    pub block_number: U256,
+    pub block_number: Option<U256>,
     /// Cumulative gas used within the block after this was executed.
     #[serde(rename = "cumulativeGasUsed")]
     pub cumulative_gas_used: U256,


### PR DESCRIPTION
`block_hash` and `block_number` are `null` if the block is pending