### PR TITLE
Fix build with OpenSSL 1.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web3"
-version = "0.4.0"
+version = "0.5.0"
 description = "Ethereum JSON-RPC client."
 homepage = "https://github.com/tomusdrw/rust-web3"
 repository = "https://github.com/tomusdrw/rust-web3"
@@ -25,14 +25,15 @@ serde_derive = "1.0"
 serde_json = "1.0"
 tokio-timer = "0.1"
 url = "1.7"
+base64 = "0.10"
 # Optional deps
-hyper = { version = "0.11", optional = true }
-hyper-tls = { version = "0.1", optional = true }
-native-tls = { version = "0.1", optional = true }
+hyper = { version = "0.12", optional = true }
+hyper-tls = { version = "0.3", optional = true }
+native-tls = { version = "0.2", optional = true }
 tokio-core = { version = "0.1", optional = true }
 tokio-io = { version = "0.1", optional = true }
 tokio-uds = { version = "0.1", optional = true }
-websocket = { version = "0.20", optional = true }
+websocket = { version = "0.21", optional = true }
 
 [dev-dependencies]
 # For examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ extern crate parking_lot;
 extern crate rustc_hex;
 extern crate serde;
 extern crate tokio_timer;
+extern crate base64;
 
 #[cfg_attr(test, macro_use)]
 extern crate serde_json;

--- a/src/transports/http.rs
+++ b/src/transports/http.rs
@@ -167,10 +167,10 @@ impl Http {
         if len < MAX_SINGLE_CHUNK {
             req.headers_mut().insert(hyper::header::CONTENT_LENGTH, len.into());
         }
+        // Send basic auth header
         if let Some(ref basic_auth) = self.basic_auth {
             req.headers_mut().insert(hyper::header::AUTHORIZATION, basic_auth.clone());
         }
-        // Send basic auth header
         let (tx, rx) = futures::oneshot();
         let result = self.write_sender
             .unbounded_send((req, tx))

--- a/src/transports/http.rs
+++ b/src/transports/http.rs
@@ -14,9 +14,11 @@ use std::sync::atomic::{self, AtomicUsize};
 
 use futures::sync::{mpsc, oneshot};
 use futures::{self, future, Future, Stream};
+use self::hyper::header::HeaderValue;
 use helpers;
 use rpc;
 use serde_json;
+use base64;
 use transports::Result;
 use transports::shared::{EventLoopHandle, Response};
 use transports::tokio_core::reactor;
@@ -29,9 +31,15 @@ impl From<hyper::Error> for Error {
     }
 }
 
-impl From<hyper::error::UriError> for Error {
-    fn from(err: hyper::error::UriError) -> Self {
+impl From<hyper::http::uri::InvalidUri> for Error {
+    fn from(err: hyper::http::uri::InvalidUri) -> Self {
         ErrorKind::Transport(format!("{:?}", err)).into()
+    }
+}
+
+impl From<hyper::header::InvalidHeaderValue> for Error {
+    fn from(err: hyper::header::InvalidHeaderValue) -> Self {
+        ErrorKind::Transport(format!("{}", err)).into()
     }
 }
 
@@ -62,8 +70,8 @@ pub type FetchTask<F> = Response<F, hyper::Chunk>;
 pub struct Http {
     id: Arc<AtomicUsize>,
     url: hyper::Uri,
-    basic_auth: Option<hyper::header::Basic>,
-    write_sender: mpsc::UnboundedSender<(hyper::client::Request, Pending)>,
+    basic_auth: Option<HeaderValue>,
+    write_sender: mpsc::UnboundedSender<(hyper::Request<hyper::Body>, Pending)>,
 }
 
 impl Http {
@@ -86,12 +94,11 @@ impl Http {
         let (write_sender, write_receiver) = mpsc::unbounded();
 
         #[cfg(feature = "tls")]
-        let client = hyper::Client::configure()
-            .connector(hyper_tls::HttpsConnector::new(4, handle)?)
-            .build(handle);
+        let client = hyper::Client::builder()
+          .build::<_, hyper::Body>(hyper_tls::HttpsConnector::new(4)?);
 
         #[cfg(not(feature = "tls"))]
-        let client = hyper::Client::new(handle);
+        let client = hyper::Client::new();
 
         handle.spawn(
             write_receiver
@@ -107,7 +114,7 @@ impl Http {
                         Ok(ref res) if !res.status().is_success() => A(future::err(
                             ErrorKind::Transport(format!("Unexpected response status code: {}", res.status())).into(),
                         )),
-                        Ok(res) => B(res.body().concat2().map_err(Into::into)),
+                        Ok(res) => B(res.into_body().concat2().map_err(Into::into)),
                         Err(err) => A(future::err(err.into())),
                     };
                     future.then(move |result| {
@@ -119,15 +126,17 @@ impl Http {
                 }),
         );
 
+
         let basic_auth = {
             let url = Url::parse(url)?;
             let user = url.username();
 
             if user.len() > 0 {
-                Some(hyper::header::Basic {
-                    username: user.into(),
-                    password: url.password().map(Into::into),
-                })
+                let auth = match url.password() {
+                    Some(pass) => format!("{}:{}", user, pass),
+                    None => format!("{}:", user)
+                };
+                Some(HeaderValue::from_str(&format!("Basic {}", base64::encode(&auth)))?)
             } else {
                 None
             }
@@ -147,24 +156,21 @@ impl Http {
     {
         let request = helpers::to_string(&request);
         debug!("[{}] Sending: {} to {}", id, request, self.url);
-
-        let mut req = hyper::client::Request::new(hyper::Method::Post, self.url.clone());
-        req.headers_mut().set(hyper::header::ContentType::json());
-        req.headers_mut()
-            .set(hyper::header::UserAgent::new("web3.rs"));
         let len = request.len();
+        let mut req = hyper::Request::new(hyper::Body::from(request));
+        *req.method_mut() = hyper::Method::POST;
+        *req.uri_mut() = self.url.clone();
+        req.headers_mut().insert(hyper::header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        req.headers_mut().insert(hyper::header::USER_AGENT, HeaderValue::from_static("web3.rs"));
+
         // Don't send chunked request
         if len < MAX_SINGLE_CHUNK {
-            req.headers_mut()
-                .set(hyper::header::ContentLength(len as u64));
+            req.headers_mut().insert(hyper::header::CONTENT_LENGTH, len.into());
+        }
+        if let Some(ref basic_auth) = self.basic_auth {
+            req.headers_mut().insert(hyper::header::AUTHORIZATION, basic_auth.clone());
         }
         // Send basic auth header
-        if let Some(ref basic_auth) = self.basic_auth {
-            req.headers_mut()
-                .set(hyper::header::Authorization(basic_auth.clone()));
-        }
-        req.set_body(request);
-
         let (tx, rx) = futures::oneshot();
         let result = self.write_sender
             .unbounded_send((req, tx))


### PR DESCRIPTION
Update hyper to 0.12
Update hyper-tls to 0.3
update websocket to 0.21
Update http.rs to new hyper 0.12 API
bump version

Fixes #162 

This fix means upgrading to hyper 0.12 to support OpenSSL 1.1.1. This works out OK, but the largest change to take note of would probably be the removal of typed-headers in 0.12. 