### PR TITLE
Increased the number of possible outputs from a web3 query

### DIFF
--- a/src/contract/tokens.rs
+++ b/src/contract/tokens.rs
@@ -60,7 +60,17 @@ impl_output!(2, A, B,);
 impl_output!(3, A, B, C,);
 impl_output!(4, A, B, C, D,);
 impl_output!(5, A, B, C, D, E,);
-
+impl_output!(6, A, B, C, D, E, F,);
+impl_output!(7, A, B, C, D, E, F, G,);
+impl_output!(8, A, B, C, D, E, F, G, H,);
+impl_output!(9, A, B, C, D, E, F, G, H, I,);
+impl_output!(10, A, B, C, D, E, F, G, H, I, J,);
+impl_output!(11, A, B, C, D, E, F, G, H, I, J, K,);
+impl_output!(12, A, B, C, D, E, F, G, H, I, J, K, L,);
+impl_output!(13, A, B, C, D, E, F, G, H, I, J, K, L, M,);
+impl_output!(14, A, B, C, D, E, F, G, H, I, J, K, L, M, N,);
+impl_output!(15, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O,);
+impl_output!(16, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P,);
 /// Tokens conversion trait
 pub trait Tokenize {
     /// Convert to list of tokens


### PR DESCRIPTION
Hi,
Until now it was only possible to retrieve 5 arguments as a return value from a query function because `Detokenize` was implemented only up to a tuple of 5.
I modified it so it will match the number of possible inputs - 16.

It's not the most efficient way to do it, but I guess that's a deeper problem to solve.
