### PR TITLE
Implement personal_signTransaction

### DIFF
--- a/src/api/personal.rs
+++ b/src/api/personal.rs
@@ -2,7 +2,7 @@
 
 use api::Namespace;
 use helpers::{self, CallFuture};
-use types::{Address, H256, TransactionRequest};
+use types::{Address, H256, TransactionRequest, SignedTransaction};
 
 use Transport;
 
@@ -63,6 +63,18 @@ impl<T: Transport> Personal<T> {
                 .execute("personal_sendTransaction", vec![transaction, password]),
         )
     }
+
+    /// Signs a transaction without dispatching it to the network.
+    /// The account does not need to be unlocked to make this call, and will not be left unlocked after.
+    /// Returns a signed transaction in raw bytes along with details.
+    pub fn sign_transaction(&self, transaction: TransactionRequest, password: &str) -> CallFuture<SignedTransaction, T::Out> {
+        let transaction = helpers::serialize(&transaction);
+        let password = helpers::serialize(&password);
+        CallFuture::new(
+            self.transport
+                .execute("personal_signTransaction", vec![transaction, password]),
+        )
+    }
 }
 
 #[cfg(test)]
@@ -71,9 +83,27 @@ mod tests {
 
     use api::Namespace;
     use rpc::Value;
-    use types::TransactionRequest;
+    use types::{TransactionRequest, SignedTransaction};
+    use rustc_hex::FromHex;
 
     use super::Personal;
+
+    const EXAMPLE_TX: &'static str = r#"{
+    "raw": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",
+    "tx": {
+      "hash": "0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b",
+      "nonce": "0x0",
+      "blockHash": "0xbeab0aa2411b7ab17f30a99d3cb9c6ef2fc5426d6ad6fd9e2a26a6aed1d1055b",
+      "blockNumber": "0x15df",
+      "transactionIndex": "0x1",
+      "from": "0x407d73d8a49eeb85d32cf465507dd71d507100c1",
+      "to": "0x853f43d8a49eeb85d32cf465507dd71d507100c1",
+      "value": "0x7f110",
+      "gas": "0x7f110",
+      "gasPrice": "0x09184e72a000",
+      "input": "0x603880600c6000396000f300603880600c6000396000f3603880600c6000396000f360"
+    }
+  }"#;
 
     rpc_test! (
     Personal:list_accounts => "personal_listAccounts";
@@ -102,5 +132,22 @@ mod tests {
     =>
     "personal_sendTransaction", vec![r#"{"from":"0x0000000000000000000000000000000000000123","gasPrice":"0x1","to":"0x0000000000000000000000000000000000000123","value":"0x1"}"#, r#""hunter2""#];
     Value::String("0x0000000000000000000000000000000000000000000000000000000000000123".into()) => 0x123
+  );
+
+    rpc_test! (
+    Personal:sign_transaction, TransactionRequest {
+      from: "0x407d73d8a49eeb85d32cf465507dd71d507100c1".into(),
+      to: Some("0x853f43d8a49eeb85d32cf465507dd71d507100c1".into()),
+      gas: Some(0x7f110.into()),
+      gas_price: Some(0x09184e72a000u64.into()),
+      value: Some(0x7f110.into()),
+      data: Some(FromHex::from_hex("603880600c6000396000f300603880600c6000396000f3603880600c6000396000f360").unwrap().into()),
+      nonce: Some(0x0.into()),
+      condition: None,
+    }, "hunter2"
+    =>
+    "personal_signTransaction", vec![r#"{"data":"0x603880600c6000396000f300603880600c6000396000f3603880600c6000396000f360","from":"0x407d73d8a49eeb85d32cf465507dd71d507100c1","gas":"0x7f110","gasPrice":"0x9184e72a000","nonce":"0x0","to":"0x853f43d8a49eeb85d32cf465507dd71d507100c1","value":"0x7f110"}"#, r#""hunter2""#];
+    ::serde_json::from_str(EXAMPLE_TX).unwrap()
+    => ::serde_json::from_str::<SignedTransaction>(EXAMPLE_TX).unwrap()
   );
 }

--- a/src/api/personal.rs
+++ b/src/api/personal.rs
@@ -2,7 +2,7 @@
 
 use api::Namespace;
 use helpers::{self, CallFuture};
-use types::{Address, H256, TransactionRequest, SignedTransaction};
+use types::{Address, H256, TransactionRequest, RawTransaction};
 
 use Transport;
 
@@ -66,9 +66,8 @@ impl<T: Transport> Personal<T> {
 
     /// Signs a transaction without dispatching it to the network.
     /// The account does not need to be unlocked to make this call, and will not be left unlocked after.
-    /// NOTE: Transaction details are not taken from JSON response because they're different between Geth and Parity.
-    /// Returns a signed transaction in raw bytes.
-    pub fn sign_transaction(&self, transaction: TransactionRequest, password: &str) -> CallFuture<SignedTransaction, T::Out> {
+    /// Returns a signed transaction in raw bytes along with it's details.
+    pub fn sign_transaction(&self, transaction: TransactionRequest, password: &str) -> CallFuture<RawTransaction, T::Out> {
         let transaction = helpers::serialize(&transaction);
         let password = helpers::serialize(&password);
         CallFuture::new(
@@ -84,13 +83,26 @@ mod tests {
 
     use api::Namespace;
     use rpc::Value;
-    use types::{TransactionRequest, SignedTransaction};
+    use types::{TransactionRequest, RawTransaction};
     use rustc_hex::FromHex;
 
     use super::Personal;
 
     const EXAMPLE_TX: &'static str = r#"{
-    "raw": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"
+    "raw": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",
+    "tx": {
+      "hash": "0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b",
+      "nonce": "0x0",
+      "blockHash": "0xbeab0aa2411b7ab17f30a99d3cb9c6ef2fc5426d6ad6fd9e2a26a6aed1d1055b",
+      "blockNumber": "0x15df",
+      "transactionIndex": "0x1",
+      "from": "0x407d73d8a49eeb85d32cf465507dd71d507100c1",
+      "to": "0x853f43d8a49eeb85d32cf465507dd71d507100c1",
+      "value": "0x7f110",
+      "gas": "0x7f110",
+      "gasPrice": "0x09184e72a000",
+      "input": "0x603880600c6000396000f300603880600c6000396000f3603880600c6000396000f360"
+    }
   }"#;
 
     rpc_test! (
@@ -136,6 +148,6 @@ mod tests {
     =>
     "personal_signTransaction", vec![r#"{"data":"0x603880600c6000396000f300603880600c6000396000f3603880600c6000396000f360","from":"0x407d73d8a49eeb85d32cf465507dd71d507100c1","gas":"0x7f110","gasPrice":"0x9184e72a000","nonce":"0x0","to":"0x853f43d8a49eeb85d32cf465507dd71d507100c1","value":"0x7f110"}"#, r#""hunter2""#];
     ::serde_json::from_str(EXAMPLE_TX).unwrap()
-    => ::serde_json::from_str::<SignedTransaction>(EXAMPLE_TX).unwrap()
+    => ::serde_json::from_str::<RawTransaction>(EXAMPLE_TX).unwrap()
   );
 }

--- a/src/api/personal.rs
+++ b/src/api/personal.rs
@@ -66,7 +66,8 @@ impl<T: Transport> Personal<T> {
 
     /// Signs a transaction without dispatching it to the network.
     /// The account does not need to be unlocked to make this call, and will not be left unlocked after.
-    /// Returns a signed transaction in raw bytes along with details.
+    /// NOTE: Transaction details are not taken from JSON response because they're different between Geth and Parity.
+    /// Returns a signed transaction in raw bytes.
     pub fn sign_transaction(&self, transaction: TransactionRequest, password: &str) -> CallFuture<SignedTransaction, T::Out> {
         let transaction = helpers::serialize(&transaction);
         let password = helpers::serialize(&password);
@@ -89,20 +90,7 @@ mod tests {
     use super::Personal;
 
     const EXAMPLE_TX: &'static str = r#"{
-    "raw": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",
-    "tx": {
-      "hash": "0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b",
-      "nonce": "0x0",
-      "blockHash": "0xbeab0aa2411b7ab17f30a99d3cb9c6ef2fc5426d6ad6fd9e2a26a6aed1d1055b",
-      "blockNumber": "0x15df",
-      "transactionIndex": "0x1",
-      "from": "0x407d73d8a49eeb85d32cf465507dd71d507100c1",
-      "to": "0x853f43d8a49eeb85d32cf465507dd71d507100c1",
-      "value": "0x7f110",
-      "gas": "0x7f110",
-      "gasPrice": "0x09184e72a000",
-      "input": "0x603880600c6000396000f300603880600c6000396000f3603880600c6000396000f360"
-    }
+    "raw": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"
   }"#;
 
     rpc_test! (

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -16,7 +16,7 @@ pub use self::block::{Block, BlockHeader, BlockId, BlockNumber};
 pub use self::bytes::Bytes;
 pub use self::log::{Filter, FilterBuilder, Log};
 pub use self::sync_state::{SyncInfo, SyncState};
-pub use self::transaction::{Receipt as TransactionReceipt, Transaction, SignedTransaction};
+pub use self::transaction::{Receipt as TransactionReceipt, Transaction, RawTransaction};
 pub use self::transaction_id::TransactionId;
 pub use self::transaction_request::{CallRequest, TransactionCondition, TransactionRequest};
 pub use self::uint::{H128, H160, H2048, H256, H512, H520, H64, U128, U256, U64};

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -16,7 +16,7 @@ pub use self::block::{Block, BlockHeader, BlockId, BlockNumber};
 pub use self::bytes::Bytes;
 pub use self::log::{Filter, FilterBuilder, Log};
 pub use self::sync_state::{SyncInfo, SyncState};
-pub use self::transaction::{Receipt as TransactionReceipt, Transaction};
+pub use self::transaction::{Receipt as TransactionReceipt, Transaction, SignedTransaction};
 pub use self::transaction_id::TransactionId;
 pub use self::transaction_request::{CallRequest, TransactionCondition, TransactionRequest};
 pub use self::uint::{H128, H160, H2048, H256, H512, H520, H64, U128, U256, U64};

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -68,16 +68,55 @@ pub struct Receipt {
 
 /// Raw bytes of a signed, but not yet sent transaction
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
-pub struct SignedTransaction {
+pub struct RawTransaction {
   /// Signed transaction as raw bytes
   pub raw: Bytes,
+  /// Transaction details
+  pub tx: RawTransactionDetails
+}
+
+/// Details of a signed transaction
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RawTransactionDetails {
+  /// Hash
+  pub hash: H256,
+  /// Nonce
+  pub nonce: U256,
+  /// Block hash. None when pending.
+  #[serde(rename = "blockHash")]
+  pub block_hash: Option<H256>,
+  /// Block number. None when pending.
+  #[serde(rename = "blockNumber")]
+  pub block_number: Option<U256>,
+  /// Transaction Index. None when pending.
+  #[serde(rename = "transactionIndex")]
+  pub transaction_index: Option<Index>,
+  /// Sender
+  pub from: Option<H160>,
+  /// Recipient (None when contract creation)
+  pub to: Option<H160>,
+  /// Transfered value
+  pub value: U256,
+  /// Gas Price
+  #[serde(rename = "gasPrice")]
+  pub gas_price: U256,
+  /// Gas amount
+  pub gas: U256,
+  /// Input data
+  pub input: Bytes,
+  /// ECDSA recovery id, set by Geth
+  pub v: Option<U64>,
+  /// ECDSA signature r, 32 bytes, set by Geth
+  pub r: Option<Bytes>,
+  /// ECDSA signature s, 32 bytes, set by Geth
+  pub s: Option<Bytes>,
 }
 
 #[cfg(test)]
 mod tests {
     use serde_json;
     use super::Receipt;
-    use super::SignedTransaction;
+    use super::RawTransaction;
 
     #[test]
     fn test_deserialize_receipt() {
@@ -125,11 +164,46 @@ mod tests {
     }
 
     #[test]
-    fn test_deserialize_signed_tx() {
-      let tx_str = r#"{
-      "raw": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"
+    fn test_deserialize_signed_tx_parity() {
+        // taken from RPC docs.
+        let tx_str = r#"{
+        "raw": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",
+        "tx": {
+          "hash": "0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b",
+          "nonce": "0x0",
+          "blockHash": "0xbeab0aa2411b7ab17f30a99d3cb9c6ef2fc5426d6ad6fd9e2a26a6aed1d1055b",
+          "blockNumber": "0x15df",
+          "transactionIndex": "0x1",
+          "from": "0x407d73d8a49eeb85d32cf465507dd71d507100c1",
+          "to": "0x853f43d8a49eeb85d32cf465507dd71d507100c1",
+          "value": "0x7f110",
+          "gas": "0x7f110",
+          "gasPrice": "0x09184e72a000",
+          "input": "0x603880600c6000396000f300603880600c6000396000f3603880600c6000396000f360"
+        }
     }"#;
 
-        let _tx: SignedTransaction = serde_json::from_str(tx_str).unwrap();
+        let _tx: RawTransaction = serde_json::from_str(tx_str).unwrap();
+    }
+
+    #[test]
+    fn test_deserialize_signed_tx_geth() {
+        let tx_str = r#"{
+        "raw": "0xf85d01018094f3b3138e5eb1c75b43994d1bb760e2f9f735789680801ca06484d00575e961a7db35ebe5badaaca5cb7ee65d1f2f22f22da87c238b99d30da07a85d65797e4b555c1d3f64beebb2cb6f16a6fbd40c43cc48451eaf85305f66e",
+        "tx": {
+          "gas": "0x0",
+          "gasPrice": "0x1",
+          "hash": "0x0a32fb4e18bc6f7266a164579237b1b5c74271d453c04eab70444ca367d38418",
+          "input": "0x",
+          "nonce": "0x1",
+          "to": "0xf3b3138e5eb1c75b43994d1bb760e2f9f7357896",
+          "r": "0x6484d00575e961a7db35ebe5badaaca5cb7ee65d1f2f22f22da87c238b99d30d",
+          "s": "0x7a85d65797e4b555c1d3f64beebb2cb6f16a6fbd40c43cc48451eaf85305f66e",
+          "v": "0x1c",
+          "value": "0x0"
+        }
+    }"#;
+
+        let _tx: RawTransaction = serde_json::from_str(tx_str).unwrap();
     }
 }

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -66,10 +66,20 @@ pub struct Receipt {
     pub logs_bloom: H2048,
 }
 
+/// Raw bytes and details of a signed, but not yet sent transaction
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SignedTransaction {
+  /// Signed transaction as raw bytes
+  pub raw: Bytes,
+  /// Transaction details
+  pub tx: Transaction,
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json;
     use super::Receipt;
+    use super::SignedTransaction;
 
     #[test]
     fn test_deserialize_receipt() {
@@ -114,5 +124,28 @@ mod tests {
     }"#;
 
         let _receipt: Receipt = serde_json::from_str(receipt_str).unwrap();
+    }
+
+    #[test]
+    fn test_deserialize_signed_tx() {
+      // taken from RPC docs.
+      let tx_str = r#"{
+      "raw": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",
+      "tx": {
+        "hash": "0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b",
+        "nonce": "0x0",
+        "blockHash": "0xbeab0aa2411b7ab17f30a99d3cb9c6ef2fc5426d6ad6fd9e2a26a6aed1d1055b",
+        "blockNumber": "0x15df",
+        "transactionIndex": "0x1",
+        "from": "0x407d73d8a49eeb85d32cf465507dd71d507100c1",
+        "to": "0x853f43d8a49eeb85d32cf465507dd71d507100c1",
+        "value": "0x7f110",
+        "gas": "0x7f110",
+        "gasPrice": "0x09184e72a000",
+        "input": "0x603880600c6000396000f300603880600c6000396000f3603880600c6000396000f360"
+      }
+    }"#;
+
+        let _tx: SignedTransaction = serde_json::from_str(tx_str).unwrap();
     }
 }

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -66,13 +66,11 @@ pub struct Receipt {
     pub logs_bloom: H2048,
 }
 
-/// Raw bytes and details of a signed, but not yet sent transaction
+/// Raw bytes of a signed, but not yet sent transaction
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SignedTransaction {
   /// Signed transaction as raw bytes
   pub raw: Bytes,
-  /// Transaction details
-  pub tx: Transaction,
 }
 
 #[cfg(test)]
@@ -128,22 +126,8 @@ mod tests {
 
     #[test]
     fn test_deserialize_signed_tx() {
-      // taken from RPC docs.
       let tx_str = r#"{
-      "raw": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",
-      "tx": {
-        "hash": "0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b",
-        "nonce": "0x0",
-        "blockHash": "0xbeab0aa2411b7ab17f30a99d3cb9c6ef2fc5426d6ad6fd9e2a26a6aed1d1055b",
-        "blockNumber": "0x15df",
-        "transactionIndex": "0x1",
-        "from": "0x407d73d8a49eeb85d32cf465507dd71d507100c1",
-        "to": "0x853f43d8a49eeb85d32cf465507dd71d507100c1",
-        "value": "0x7f110",
-        "gas": "0x7f110",
-        "gasPrice": "0x09184e72a000",
-        "input": "0x603880600c6000396000f300603880600c6000396000f3603880600c6000396000f360"
-      }
+      "raw": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"
     }"#;
 
         let _tx: SignedTransaction = serde_json::from_str(tx_str).unwrap();


### PR DESCRIPTION
I've introduced a new type `SignedTransaction` which has just a single field `raw: Bytes`. Both Parity and Geth also return `tx` field in response, but I ignored it because it's different between Parity and Geth.

*Parity 2.2.7 (stable)* response looks like this (it's from docs, but I tested it, it looks like this):
```json
{
  "id": 1,
  "jsonrpc": "2.0",
  "result": {
    "raw": "..",
    "tx": {
      "hash": "0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b",
      "nonce": "0x0",
      "blockHash": "0xbeab0aa2411b7ab17f30a99d3cb9c6ef2fc5426d6ad6fd9e2a26a6aed1d1055b",
      "blockNumber": "0x15df",
      "transactionIndex": "0x1",
      "from": "0x407d73d8a49eeb85d32cf465507dd71d507100c1",
      "to": "0x853f43d8a49eeb85d32cf465507dd71d507100c1",
      "value": "0x7f110",
      "gas": "0x7f110",
      "gasPrice": "0x09184e72a000",
      "input": "0x603880600c6000396000f300603880600c6000396000f3603880600c6000396000f360"
    }
  }
}
```

*Geth 1.8.22 (unstable)* response looks like this:
```json
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": {
        "raw": "..",
        "tx": {
            "nonce": "0x0",
            "gasPrice": "0xffff",
            "gas": "0xf4240",
            "to": "0x9a3027b366a50b3b451811e9b4cf48b4f96d780e",
            "value": "0xffff",
            "input": "0x",
            "v": "0x9c8",
            "r": "0x4a3a70f717b8a9a5f2fc2ab2814d00d61a11f7678047b8cd6bbe402be56bf316",
            "s": "0x588c81b447319cd164cc8717311027a0f032f1bb405b94122a817b681fab7557",
            "hash": "0xc46996c2c0d291266c24d21b2abe1de2150a3a59f5182d98e57f868b50abd79e"
        }
    }
}
```

The main reason is that Geth misses `from` which is a non-optional field in `web3::transaction::Transaction`, so straightforward deserialization isn't possible. 

Maybe there is some workaround since we actually always know `from`, and maybe there is a way to make `serde` use it. But I don't really see a point in that, since sender already have all that info in `TransactionRequest`.

That said, maybe there is a point in returning `Bytes` directly, avoiding `SignedTransaction` wrapper altogether. But I'm not sure of an idiomatic way to do that, so I could use advice if you think that's the right way.