### PR TITLE
parity_netPeers function

### DIFF
--- a/src/api/net.rs
+++ b/src/api/net.rs
@@ -37,8 +37,8 @@ impl<T: Transport> Net<T> {
     }
 
     /// Returns list of connected nodes
-    pub fn peer_list(&self, _n: NodeType) -> CallFuture<PeerType, T::Out>{
-        match _n {
+    pub fn peer_list(&self, n: NodeType) -> CallFuture<PeerType, T::Out>{
+        match n {
             NodeType::Parity => CallFuture::new(self.transport.execute("parity_netPeers", vec![])),
             NodeType::Geth => CallFuture::new(self.transport.execute("admin_peers", vec![])),
         }

--- a/src/api/net.rs
+++ b/src/api/net.rs
@@ -2,7 +2,7 @@
 
 use api::Namespace;
 use helpers::CallFuture;
-use types::U256;
+use types::{U256, PeerType, NodeType};
 
 use Transport;
 
@@ -34,6 +34,14 @@ impl<T: Transport> Net<T> {
     /// Returns number of peers connected to node.
     pub fn peer_count(&self) -> CallFuture<U256, T::Out> {
         CallFuture::new(self.transport.execute("net_peerCount", vec![]))
+    }
+
+    /// Returns list of connected nodes
+    pub fn peer_list(&self, _n: NodeType) -> CallFuture<PeerType, T::Out>{
+        match _n {
+            NodeType::Parity => CallFuture::new(self.transport.execute("parity_netPeers", vec![])),
+            NodeType::Geth => CallFuture::new(self.transport.execute("admin_peers", vec![])),
+        }
     }
 
     /// Whether the node is listening for network connections

--- a/src/api/net.rs
+++ b/src/api/net.rs
@@ -2,7 +2,7 @@
 
 use api::Namespace;
 use helpers::CallFuture;
-use types::{U256, PeerType, NodeType};
+use types::{U256, PeerType};
 
 use Transport;
 
@@ -36,12 +36,9 @@ impl<T: Transport> Net<T> {
         CallFuture::new(self.transport.execute("net_peerCount", vec![]))
     }
 
-    /// Returns list of connected nodes
-    pub fn peer_list(&self, n: NodeType) -> CallFuture<PeerType, T::Out>{
-        match n {
-            NodeType::Parity => CallFuture::new(self.transport.execute("parity_netPeers", vec![])),
-            NodeType::Geth => CallFuture::new(self.transport.execute("admin_peers", vec![])),
-        }
+    /// Returns list of connected nodes parity
+    pub fn parity_peer_list(&self) -> CallFuture<PeerType, T::Out>{
+        CallFuture::new(self.transport.execute("parity_netPeers", vec![]))
     }
 
     /// Whether the node is listening for network connections

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -11,6 +11,8 @@ mod uint;
 mod work;
 mod traces;
 mod trace_filtering;
+mod node;
+mod peer;
 
 pub use self::block::{Block, BlockHeader, BlockId, BlockNumber};
 pub use self::bytes::Bytes;
@@ -23,7 +25,8 @@ pub use self::uint::{H128, H160, H2048, H256, H512, H520, H64, U128, U256, U64};
 pub use self::work::Work;
 pub use self::trace_filtering::{Trace, TraceFilter, TraceFilterBuilder, Res, Action, CallType};
 pub use self::traces::{TraceType, BlockTrace, TransactionTrace};
-
+pub use self::node::{NodeType};
+pub use self::peer::{PeerType};
 /// Address
 pub type Address = H160;
 /// Index in block

--- a/src/types/node.rs
+++ b/src/types/node.rs
@@ -1,0 +1,6 @@
+//! Type of node (Parity, Geth...)
+
+pub enum NodeType {
+    Parity,
+    Geth,
+}

--- a/src/types/node.rs
+++ b/src/types/node.rs
@@ -1,6 +1,9 @@
 //! Type of node (Parity, Geth...)
 
+/// specify behavior of node interacting with
 pub enum NodeType {
+    /// parity node
     Parity,
+    /// geth node
     Geth,
 }

--- a/src/types/peer.rs
+++ b/src/types/peer.rs
@@ -1,9 +1,11 @@
 //! Types for getting peer information
 use ethereum_types::U256;
+
 use serde_derive::{Deserialize, Serialize};
 
+
 /// Stores active peer count, connected count, max connected peers
-/// and a list of peers
+/// and a list of peers for parity node
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PeerType {
     /// number of active peers
@@ -17,6 +19,7 @@ pub struct PeerType {
 }
 
 /// details of a peer
+// also used for geth nodes
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PeerInfo {
     /// id of peer
@@ -58,4 +61,5 @@ pub struct PipProtocolInfo {
     pub difficulty: U256,
     pub head: String,
 }
+
 

--- a/src/types/peer.rs
+++ b/src/types/peer.rs
@@ -1,0 +1,66 @@
+use ethereum_types::U256;
+use serde_derive::{Deserialize, Serialize};
+
+use std::fmt;
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct PeerType {
+    pub active: usize,
+    pub connected: usize,
+    pub max: u32,
+    pub peers: Vec<PeerInfo>,
+}
+
+impl fmt::Debug for PeerType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "active: {}, connected: {}, max: {}, peers: {:?}", self.active, self.connected, self.max, self.peers)
+
+    }
+}
+
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct PeerInfo {
+    pub id: Option<String>,
+    pub name: String,
+    pub caps: Vec<String>,
+    pub network: PeerNetworkInfo,
+    pub protocols: PeerProtocolsInfo,
+}
+impl fmt::Debug for PeerInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "id: {:?}, name: {}, caps: {:?}, remote address: {}, local address: {}", self.id, self.name, self.caps, self.network.remote_address, self.network.local_address)
+    }
+}
+
+
+#[derive(Serialize, Clone, Deserialize, Debug)]
+pub struct PeerNetworkInfo {
+
+    #[serde(rename="remoteAddress")]
+    pub remote_address: String,
+
+    #[serde(rename="localAddress")]
+    pub local_address: String,
+}
+
+#[derive(Serialize, Clone, Deserialize, Debug)]
+pub struct PeerProtocolsInfo {
+    pub eth: Option<EthProtocolInfo>,
+    pub pip: Option<PipProtocolInfo>,
+}
+
+#[derive(Serialize, Clone, Deserialize, Debug)]
+pub struct EthProtocolInfo {
+    pub version: u32,
+    pub difficulty: Option<U256>,
+    pub head: String,
+}
+
+#[derive(Serialize, Clone, Deserialize, Debug)]
+pub struct PipProtocolInfo {
+    pub version: u32,
+    pub difficulty: U256,
+    pub head: String,
+}
+

--- a/src/types/peer.rs
+++ b/src/types/peer.rs
@@ -1,56 +1,51 @@
+//! Types for getting peer information
 use ethereum_types::U256;
 use serde_derive::{Deserialize, Serialize};
 
-use std::fmt;
-
-#[derive(Serialize, Deserialize, Clone)]
+/// Stores active peer count, connected count, max connected peers
+/// and a list of peers
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PeerType {
+    /// number of active peers
     pub active: usize,
+    /// number of connected peers
     pub connected: usize,
+    /// maximum number of peers that can connect
     pub max: u32,
+    /// list of all peers with details
     pub peers: Vec<PeerInfo>,
 }
 
-impl fmt::Debug for PeerType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "active: {}, connected: {}, max: {}, peers: {:?}", self.active, self.connected, self.max, self.peers)
-
-    }
-}
-
-
-#[derive(Serialize, Deserialize, Clone)]
+/// details of a peer
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PeerInfo {
+    /// id of peer
     pub id: Option<String>,
+    /// name of peer if set by user
     pub name: String,
+    /// sync logic for protocol messaging
     pub caps: Vec<String>,
+    /// remote address and local address
     pub network: PeerNetworkInfo,
+    /// protocol version of peer
     pub protocols: PeerProtocolsInfo,
 }
-impl fmt::Debug for PeerInfo {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "id: {:?}, name: {}, caps: {:?}, remote address: {}, local address: {}", self.id, self.name, self.caps, self.network.remote_address, self.network.local_address)
-    }
-}
 
-
-#[derive(Serialize, Clone, Deserialize, Debug)]
+/// ip address of both local and remote
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all="camelCase")]
 pub struct PeerNetworkInfo {
-
-    #[serde(rename="remoteAddress")]
     pub remote_address: String,
-
-    #[serde(rename="localAddress")]
     pub local_address: String,
 }
 
-#[derive(Serialize, Clone, Deserialize, Debug)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PeerProtocolsInfo {
     pub eth: Option<EthProtocolInfo>,
     pub pip: Option<PipProtocolInfo>,
 }
 
-#[derive(Serialize, Clone, Deserialize, Debug)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct EthProtocolInfo {
     pub version: u32,
     pub difficulty: Option<U256>,


### PR DESCRIPTION
geth returns a different structure. believe it is of type HashMap. thought this would be a simpler/better alternative atm until i have time to do some digging through geth's source. will setup a seperate func for geth. hope the naming scheme is ok. ``func parity_peer_list`` and ``func geth_peer_list``.