### PR TITLE
Make `Trace` struct compatible with parity-ethereum rpc

### DIFF
--- a/src/types/trace_filtering.rs
+++ b/src/types/trace_filtering.rs
@@ -82,7 +82,7 @@ pub struct Trace {
     /// Action
     pub action: Action,
     /// Result
-    pub result: Res,
+    pub result: Option<Res>,
     /// Trace address
     #[serde(rename = "traceAddress")]
     pub trace_address: Vec<usize>,
@@ -102,6 +102,8 @@ pub struct Trace {
     pub block_hash: H256,
     #[serde(rename = "type")]
     action_type: ActionType,
+    // Error
+    pub error: Option<String>,
 }
 
 /// Response


### PR DESCRIPTION
The current struct errors when de serializing traces for `FailedCall`s or `FailedCreate`s because the `result` property isn't optional. This type also isn't capturing the `error` field getting sent by the Ethereum node.

Here is the relevant type/serialization logic on the `parity-ethereum` side:
https://github.com/paritytech/parity-ethereum/blob/master/rpc/src/v1/types/trace.rs#L505-L509
