### PR TITLE
Parse r/s values from signTransaction as U256

### DIFF
--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -108,9 +108,9 @@ pub struct RawTransactionDetails {
     /// ECDSA recovery id, set by Geth
     pub v: Option<U64>,
     /// ECDSA signature r, 32 bytes, set by Geth
-    pub r: Option<Bytes>,
+    pub r: Option<U256>,
     /// ECDSA signature s, 32 bytes, set by Geth
-    pub s: Option<Bytes>,
+    pub s: Option<U256>,
 }
 
 #[cfg(test)]
@@ -180,7 +180,8 @@ mod tests {
           "value": "0x7f110",
           "gas": "0x7f110",
           "gasPrice": "0x09184e72a000",
-          "input": "0x603880600c6000396000f300603880600c6000396000f3603880600c6000396000f360"
+          "input": "0x603880600c6000396000f300603880600c6000396000f3603880600c6000396000f360",
+          "s": "0x777"
         }
     }"#;
 


### PR DESCRIPTION
Parity Ethereum also returns the `r` and `s` values in the `RawTransactionDetails` response of `personal_signTransaction`. These values are encoded as `U256` instead of fixed 32 byte strings. This results in response values that have less uneven number of hex characters. For these cases deserialization of the response fails.

To accomodate this case we change the type the `r` and `s` fields in `RawTransactionDetails`.