### PR TITLE
Add `web3::contract::deploy::execute_no_unlock`

### DIFF
--- a/src/contract/deploy.rs
+++ b/src/contract/deploy.rs
@@ -64,7 +64,7 @@ impl<T: Transport> Builder<T> {
     /// `sign_raw_transaction_with_confirmation` instead of
     /// `sign_transaction_with_confirmation`, which requires the account from
     /// which the transaction is sent to be unlocked.
-    pub fn sign_and_execute<P, V, Ft>(
+    pub fn sign_and_execute<P, V>(
         self,
         code: V,
         params: P,

--- a/src/contract/deploy.rs
+++ b/src/contract/deploy.rs
@@ -44,12 +44,11 @@ impl<T: Transport> Builder<T> {
         self
     }
 
-    fn execute_core<P, V, F>(self, code: V, params: P, from: Address, f: F) -> Result<PendingContract<T>, ethabi::Error>
+    /// Execute deployment passing code and contructor parameters.
+    pub fn execute<P, V>(self, code: V, params: P, from: Address) -> Result<PendingContract<T>, ethabi::Error>
     where
         P: Tokenize,
         V: AsRef<str>,
-        T: Transport,
-        F: Fn(TransactionRequest, T, core::time::Duration, usize) -> confirm::SendTransactionWithConfirmation<T>,
     {
         let options = self.options;
         let eth = self.eth;
@@ -90,11 +89,11 @@ impl<T: Transport> Builder<T> {
             condition: options.condition,
         };
 
-        let waiting = f(
-            tx,
+        let waiting = confirm::send_transaction_with_confirmation(
             eth.transport().clone(),
-            self.poll_interval.clone(),
-            self.confirmations.clone(),
+            tx,
+            self.poll_interval,
+            self.confirmations,
         );
 
         Ok(PendingContract {
@@ -102,19 +101,6 @@ impl<T: Transport> Builder<T> {
             abi: Some(abi),
             waiting,
         })
-    }
-
-    /// Execute deployment passing code and contructor parameters.
-    pub fn execute<P, V>(self, code: V, params: P, from: Address) -> Result<PendingContract<T>, ethabi::Error>
-    where
-        P: Tokenize,
-        V: AsRef<str>,
-        T: Transport,
-    {
-        let f = |tx, eth: T, poll_interval, confirmations| {
-            confirm::send_transaction_with_confirmation(eth, tx, poll_interval, confirmations)
-        };
-        self.execute_core(code, params, from, f)
     }
 
     /// Execute deployment passing code and contructor parameters.
@@ -136,16 +122,63 @@ impl<T: Transport> Builder<T> {
         V: AsRef<str>,
         T: Transport,
     {
-        let f = |tx, eth: T, poll_interval, confirmations| {
-            let raw_tx = web3
-                .personal()
-                .sign_transaction(tx, password)
-                .wait()
-                .expect("Transaction signing failed");
+        let options = self.options;
+        let eth = self.eth;
+        let abi = self.abi;
 
-            confirm::send_raw_transaction_with_confirmation(eth, raw_tx.raw, poll_interval, confirmations)
+        let mut code_hex = code.as_ref().to_string();
+
+        for (lib, address) in self.linker {
+            if lib.len() > 38 {
+                return Err(
+                    ethabi::ErrorKind::Msg(String::from("The library name should be under 39 characters.")).into(),
+                );
+            }
+            let replace = format!("__{:_<38}", lib); // This makes the required width 38 characters and will pad with `_` to match it.
+            let address: String = address.as_ref().to_hex();
+            code_hex = code_hex.replacen(&replace, &address, 1);
+        }
+        code_hex = code_hex.replace("\"", "").replace("0x", ""); // This is to fix truffle + serde_json redundant `"` and `0x`
+        let code = code_hex.from_hex().map_err(ethabi::ErrorKind::Hex)?;
+
+        let params = params.into_tokens();
+        let data = match (abi.constructor(), params.is_empty()) {
+            (None, false) => {
+                return Err(ethabi::ErrorKind::Msg("Constructor is not defined in the ABI.".into()).into());
+            }
+            (None, true) => code,
+            (Some(constructor), _) => constructor.encode_input(code, &params)?,
         };
-        self.execute_core(code, params, from, f)
+
+        let tx = TransactionRequest {
+            from,
+            to: None,
+            gas: options.gas,
+            gas_price: options.gas_price,
+            value: options.value,
+            nonce: options.nonce,
+            data: Some(Bytes(data)),
+            condition: options.condition,
+        };
+
+        let raw_tx = web3
+            .personal()
+            .sign_transaction(tx, password)
+            .wait()
+            .expect("Transaction signing failed");
+
+        let waiting = confirm::send_raw_transaction_with_confirmation(
+            eth.transport().clone(),
+            raw_tx.raw,
+            self.poll_interval,
+            self.confirmations,
+        );
+
+        Ok(PendingContract {
+            eth: Some(eth),
+            abi: Some(abi),
+            waiting,
+        })
     }
 }
 

--- a/src/contract/deploy.rs
+++ b/src/contract/deploy.rs
@@ -164,7 +164,7 @@ pub struct PendingContract<
     waiting: F,
 }
 
-impl<T: Transport> Future for PendingContract<T> {
+impl<T: Transport, F: Future<Item = TransactionReceipt, Error = crate::error::Error>> Future for PendingContract<T, F> {
     type Item = Contract<T>;
     type Error = Error;
 


### PR DESCRIPTION
This PR introduces a variant of `web3::contract::deploy::execute` that does not require the account for which it is used to be unlocked.