### PR TITLE
Updated blocks numbers to use U64

### DIFF
--- a/src/api/eth.rs
+++ b/src/api/eth.rs
@@ -4,7 +4,7 @@ use crate::api::Namespace;
 use crate::helpers::{self, CallFuture};
 use crate::types::{
     Address, Block, BlockId, BlockNumber, Bytes, CallRequest, Filter, Index, Log, SyncState, Transaction,
-    TransactionId, TransactionReceipt, TransactionRequest, Work, H256, H520, H64, U256,
+    TransactionId, TransactionReceipt, TransactionRequest, Work, H256, H520, H64, U128, U256,
 };
 use crate::Transport;
 
@@ -34,7 +34,7 @@ impl<T: Transport> Eth<T> {
     }
 
     /// Get current block number
-    pub fn block_number(&self) -> CallFuture<U256, T::Out> {
+    pub fn block_number(&self) -> CallFuture<U128, T::Out> {
         CallFuture::new(self.transport.execute("eth_blockNumber", vec![]))
     }
 

--- a/src/api/eth.rs
+++ b/src/api/eth.rs
@@ -4,7 +4,7 @@ use crate::api::Namespace;
 use crate::helpers::{self, CallFuture};
 use crate::types::{
     Address, Block, BlockId, BlockNumber, Bytes, CallRequest, Filter, Index, Log, SyncState, Transaction,
-    TransactionId, TransactionReceipt, TransactionRequest, Work, H256, H520, H64, U128, U256,
+    TransactionId, TransactionReceipt, TransactionRequest, Work, H256, H520, H64, U64, U256,
 };
 use crate::Transport;
 
@@ -34,7 +34,7 @@ impl<T: Transport> Eth<T> {
     }
 
     /// Get current block number
-    pub fn block_number(&self) -> CallFuture<U128, T::Out> {
+    pub fn block_number(&self) -> CallFuture<U64, T::Out> {
         CallFuture::new(self.transport.execute("eth_blockNumber", vec![]))
     }
 

--- a/src/api/eth.rs
+++ b/src/api/eth.rs
@@ -4,7 +4,7 @@ use crate::api::Namespace;
 use crate::helpers::{self, CallFuture};
 use crate::types::{
     Address, Block, BlockId, BlockNumber, Bytes, CallRequest, Filter, Index, Log, SyncState, Transaction,
-    TransactionId, TransactionReceipt, TransactionRequest, Work, H256, H520, H64, U64, U256,
+    TransactionId, TransactionReceipt, TransactionRequest, Work, H256, H520, H64, U256, U64,
 };
 use crate::Transport;
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -20,7 +20,7 @@ pub use self::personal::Personal;
 pub use self::traces::Traces;
 pub use self::web3::Web3 as Web3Api;
 
-use crate::types::{Bytes, TransactionRequest, U128};
+use crate::types::{Bytes, TransactionRequest, U64};
 use crate::{confirm, DuplexTransport, Error, Transport};
 use futures::IntoFuture;
 use std::time::Duration;
@@ -104,7 +104,7 @@ impl<T: Transport> Web3<T> {
         check: V,
     ) -> confirm::Confirmations<T, V, F::Future>
     where
-        F: IntoFuture<Item = Option<U128>, Error = Error>,
+        F: IntoFuture<Item = Option<U64>, Error = Error>,
         V: confirm::ConfirmationCheck<Check = F>,
     {
         confirm::wait_for_confirmations(self.eth(), self.eth_filter(), poll_interval, confirmations, check)

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -20,7 +20,7 @@ pub use self::personal::Personal;
 pub use self::traces::Traces;
 pub use self::web3::Web3 as Web3Api;
 
-use crate::types::{Bytes, TransactionRequest, U256};
+use crate::types::{Bytes, TransactionRequest, U128};
 use crate::{confirm, DuplexTransport, Error, Transport};
 use futures::IntoFuture;
 use std::time::Duration;
@@ -104,7 +104,7 @@ impl<T: Transport> Web3<T> {
         check: V,
     ) -> confirm::Confirmations<T, V, F::Future>
     where
-        F: IntoFuture<Item = Option<U256>, Error = Error>,
+        F: IntoFuture<Item = Option<U128>, Error = Error>,
         V: confirm::ConfirmationCheck<Check = F>,
     {
         confirm::wait_for_confirmations(self.eth(), self.eth_filter(), poll_interval, confirmations, check)

--- a/src/confirm.rs
+++ b/src/confirm.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use crate::api::{CreateFilter, Eth, EthFilter, FilterStream, Namespace};
 use crate::helpers::CallFuture;
-use crate::types::{Bytes, TransactionReceipt, TransactionRequest, H256, U128};
+use crate::types::{Bytes, TransactionReceipt, TransactionRequest, H256, U64};
 use crate::{Error, Transport};
 use futures::stream::Skip;
 use futures::{Future, IntoFuture, Poll, Stream};
@@ -12,7 +12,7 @@ use futures::{Future, IntoFuture, Poll, Stream};
 /// Checks whether an event has been confirmed.
 pub trait ConfirmationCheck {
     /// Future resolved when is known whether an event has been confirmed.
-    type Check: IntoFuture<Item = Option<U128>, Error = Error>;
+    type Check: IntoFuture<Item = Option<U64>, Error = Error>;
 
     /// Should be called to get future which resolves when confirmation state is known.
     fn check(&self) -> Self::Check;
@@ -21,7 +21,7 @@ pub trait ConfirmationCheck {
 impl<F, T> ConfirmationCheck for F
 where
     F: Fn() -> T,
-    T: IntoFuture<Item = Option<U128>, Error = Error>,
+    T: IntoFuture<Item = Option<U64>, Error = Error>,
 {
     type Check = T;
 
@@ -33,7 +33,7 @@ where
 enum WaitForConfirmationsState<F, O> {
     WaitForNextBlock,
     CheckConfirmation(F),
-    CompareConfirmations(u64, CallFuture<U128, O>),
+    CompareConfirmations(u64, CallFuture<U64, O>),
 }
 
 struct WaitForConfirmations<T, V, F>
@@ -51,7 +51,7 @@ impl<T, V, F> Future for WaitForConfirmations<T, V, F::Future>
 where
     T: Transport,
     V: ConfirmationCheck<Check = F>,
-    F: IntoFuture<Item = Option<U128>, Error = Error>,
+    F: IntoFuture<Item = Option<U64>, Error = Error>,
 {
     type Item = ();
     type Error = Error;
@@ -123,7 +123,7 @@ impl<T, V, F> Future for Confirmations<T, V, F::Future>
 where
     T: Transport,
     V: ConfirmationCheck<Check = F>,
-    F: IntoFuture<Item = Option<U128>, Error = Error>,
+    F: IntoFuture<Item = Option<U64>, Error = Error>,
 {
     type Item = ();
     type Error = Error;
@@ -163,7 +163,7 @@ pub fn wait_for_confirmations<T, V, F>(
 where
     T: Transport,
     V: ConfirmationCheck<Check = F>,
-    F: IntoFuture<Item = Option<U128>, Error = Error>,
+    F: IntoFuture<Item = Option<U64>, Error = Error>,
 {
     Confirmations::new(eth, eth_filter, poll_interval, confirmations, check)
 }
@@ -173,7 +173,7 @@ struct TransactionReceiptBlockNumber<T: Transport> {
 }
 
 impl<T: Transport> Future for TransactionReceiptBlockNumber<T> {
-    type Item = Option<U128>;
+    type Item = Option<U64>;
     type Error = Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {

--- a/src/confirm.rs
+++ b/src/confirm.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use crate::api::{CreateFilter, Eth, EthFilter, FilterStream, Namespace};
 use crate::helpers::CallFuture;
-use crate::types::{Bytes, TransactionReceipt, TransactionRequest, H256, U256};
+use crate::types::{Bytes, TransactionReceipt, TransactionRequest, H256, U128};
 use crate::{Error, Transport};
 use futures::stream::Skip;
 use futures::{Future, IntoFuture, Poll, Stream};
@@ -12,7 +12,7 @@ use futures::{Future, IntoFuture, Poll, Stream};
 /// Checks whether an event has been confirmed.
 pub trait ConfirmationCheck {
     /// Future resolved when is known whether an event has been confirmed.
-    type Check: IntoFuture<Item = Option<U256>, Error = Error>;
+    type Check: IntoFuture<Item = Option<U128>, Error = Error>;
 
     /// Should be called to get future which resolves when confirmation state is known.
     fn check(&self) -> Self::Check;
@@ -21,7 +21,7 @@ pub trait ConfirmationCheck {
 impl<F, T> ConfirmationCheck for F
 where
     F: Fn() -> T,
-    T: IntoFuture<Item = Option<U256>, Error = Error>,
+    T: IntoFuture<Item = Option<U128>, Error = Error>,
 {
     type Check = T;
 
@@ -33,7 +33,7 @@ where
 enum WaitForConfirmationsState<F, O> {
     WaitForNextBlock,
     CheckConfirmation(F),
-    CompareConfirmations(u64, CallFuture<U256, O>),
+    CompareConfirmations(u64, CallFuture<U128, O>),
 }
 
 struct WaitForConfirmations<T, V, F>
@@ -51,7 +51,7 @@ impl<T, V, F> Future for WaitForConfirmations<T, V, F::Future>
 where
     T: Transport,
     V: ConfirmationCheck<Check = F>,
-    F: IntoFuture<Item = Option<U256>, Error = Error>,
+    F: IntoFuture<Item = Option<U128>, Error = Error>,
 {
     type Item = ();
     type Error = Error;
@@ -123,7 +123,7 @@ impl<T, V, F> Future for Confirmations<T, V, F::Future>
 where
     T: Transport,
     V: ConfirmationCheck<Check = F>,
-    F: IntoFuture<Item = Option<U256>, Error = Error>,
+    F: IntoFuture<Item = Option<U128>, Error = Error>,
 {
     type Item = ();
     type Error = Error;
@@ -163,7 +163,7 @@ pub fn wait_for_confirmations<T, V, F>(
 where
     T: Transport,
     V: ConfirmationCheck<Check = F>,
-    F: IntoFuture<Item = Option<U256>, Error = Error>,
+    F: IntoFuture<Item = Option<U128>, Error = Error>,
 {
     Confirmations::new(eth, eth_filter, poll_interval, confirmations, check)
 }
@@ -173,7 +173,7 @@ struct TransactionReceiptBlockNumber<T: Transport> {
 }
 
 impl<T: Transport> Future for TransactionReceiptBlockNumber<T> {
-    type Item = Option<U256>;
+    type Item = Option<U128>;
     type Error = Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {

--- a/src/contract/deploy.rs
+++ b/src/contract/deploy.rs
@@ -293,5 +293,4 @@ mod tests {
         );
         transport.assert_no_more_requests();
     }
-
 }

--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -276,7 +276,7 @@ mod tests {
 
             // when
             token
-                .query("name", (), None, Options::default(), BlockNumber::Number(1))
+                .query("name", (), None, Options::default(), BlockNumber::Number(1.into()))
                 .wait()
                 .unwrap()
         };

--- a/src/types/block.rs
+++ b/src/types/block.rs
@@ -1,4 +1,4 @@
-use crate::types::{Bytes, H160, H2048, H256, H64, U128, U256};
+use crate::types::{Bytes, H160, H2048, H256, H64, U256, U64};
 use serde::{Deserialize, Serialize, Serializer};
 
 /// The block header type returned from RPC calls.
@@ -25,7 +25,7 @@ pub struct BlockHeader {
     #[serde(rename = "receiptsRoot")]
     pub receipts_root: H256,
     /// Block number. None if pending.
-    pub number: Option<U128>,
+    pub number: Option<U64>,
     /// Gas Used
     #[serde(rename = "gasUsed")]
     pub gas_used: U256,
@@ -74,7 +74,7 @@ pub struct Block<TX> {
     #[serde(rename = "receiptsRoot")]
     pub receipts_root: H256,
     /// Block number. None if pending.
-    pub number: Option<U128>,
+    pub number: Option<U64>,
     /// Gas Used
     #[serde(rename = "gasUsed")]
     pub gas_used: U256,

--- a/src/types/block.rs
+++ b/src/types/block.rs
@@ -120,11 +120,11 @@ pub enum BlockNumber {
     /// Pending block (not yet part of the blockchain)
     Pending,
     /// Block by number from canon chain
-    Number(u64),
+    Number(U64),
 }
 
-impl From<u64> for BlockNumber {
-    fn from(num: u64) -> Self {
+impl From<U64> for BlockNumber {
+    fn from(num: U64) -> Self {
         BlockNumber::Number(num)
     }
 }
@@ -164,8 +164,8 @@ impl Serialize for BlockId {
     }
 }
 
-impl From<u64> for BlockId {
-    fn from(num: u64) -> Self {
+impl From<U64> for BlockId {
+    fn from(num: U64) -> Self {
         BlockNumber::Number(num).into()
     }
 }

--- a/src/types/log.rs
+++ b/src/types/log.rs
@@ -1,4 +1,4 @@
-use crate::types::{BlockNumber, Bytes, H160, H256, U256};
+use crate::types::{BlockNumber, Bytes, H160, H256, U256, U64};
 use ethabi;
 use serde::{Deserialize, Serialize, Serializer};
 
@@ -16,7 +16,7 @@ pub struct Log {
     pub block_hash: Option<H256>,
     /// Block Number
     #[serde(rename = "blockNumber")]
-    pub block_number: Option<U256>,
+    pub block_number: Option<U64>,
     /// Transaction Hash
     #[serde(rename = "transactionHash")]
     pub transaction_hash: Option<H256>,

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -1,4 +1,4 @@
-use crate::types::{Bytes, Index, Log, H160, H2048, H256, U128, U256, U64};
+use crate::types::{Bytes, Index, Log, H160, H2048, H256, U256, U64};
 use serde::{Deserialize, Serialize};
 
 /// Description of a Transaction, pending or in the chain.
@@ -46,7 +46,7 @@ pub struct Receipt {
     pub block_hash: Option<H256>,
     /// Number of the block this transaction was included within.
     #[serde(rename = "blockNumber")]
-    pub block_number: Option<U128>,
+    pub block_number: Option<U64>,
     /// Cumulative gas used within the block after this was executed.
     #[serde(rename = "cumulativeGasUsed")]
     pub cumulative_gas_used: U256,

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -1,4 +1,4 @@
-use crate::types::{Bytes, Index, Log, H160, H2048, H256, U256, U64};
+use crate::types::{Bytes, Index, Log, H160, H2048, H256, U128, U256, U64};
 use serde::{Deserialize, Serialize};
 
 /// Description of a Transaction, pending or in the chain.
@@ -46,7 +46,7 @@ pub struct Receipt {
     pub block_hash: Option<H256>,
     /// Number of the block this transaction was included within.
     #[serde(rename = "blockNumber")]
-    pub block_number: Option<U256>,
+    pub block_number: Option<U128>,
     /// Cumulative gas used within the block after this was executed.
     #[serde(rename = "cumulativeGasUsed")]
     pub cumulative_gas_used: U256,

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -13,7 +13,7 @@ pub struct Transaction {
     pub block_hash: Option<H256>,
     /// Block number. None when pending.
     #[serde(rename = "blockNumber")]
-    pub block_number: Option<U256>,
+    pub block_number: Option<U64>,
     /// Transaction Index. None when pending.
     #[serde(rename = "transactionIndex")]
     pub transaction_index: Option<Index>,
@@ -88,7 +88,7 @@ pub struct RawTransactionDetails {
     pub block_hash: Option<H256>,
     /// Block number. None when pending.
     #[serde(rename = "blockNumber")]
-    pub block_number: Option<U256>,
+    pub block_number: Option<U64>,
     /// Transaction Index. None when pending.
     #[serde(rename = "transactionIndex")]
     pub transaction_index: Option<Index>,


### PR DESCRIPTION
Hey :hand:!

The following methods/types/fields were using `U256` to represent a block's number instead of, as everywhere else and decided [here](https://github.com/tomusdrw/rust-web3/issues/114#issuecomment-510003843), `U128`:
- `web3::api::Eth::block_number`
- `web3::api::Web3::wait_for_confirmations`
- `web3::confirm::ConfirmationCheck::Check` and all related structs/types
- `web3::types::TransactionReceipt.block_number`

Also, maybe `web3::types::BlockNumber` should use `U128` instead of `u64`?