### PR TITLE
Removed Res::FailedCallOrCreate and added missing fields to TransactionTrace

### DIFF
--- a/src/types/trace_filtering.rs
+++ b/src/types/trace_filtering.rs
@@ -114,8 +114,6 @@ pub enum Res {
     Call(CallResult),
     /// Create
     Create(CreateResult),
-    /// Call or Create failure
-    FailedCallOrCreate(String),
     /// None
     None,
 }

--- a/src/types/trace_filtering.rs
+++ b/src/types/trace_filtering.rs
@@ -100,6 +100,7 @@ pub struct Trace {
     /// Block Hash
     #[serde(rename = "blockHash")]
     pub block_hash: H256,
+    /// Action Type
     #[serde(rename = "type")]
     action_type: ActionType,
     /// Error

--- a/src/types/traces.rs
+++ b/src/types/traces.rs
@@ -80,8 +80,8 @@ pub struct TransactionTrace {
     action: Action,
     /// Result
     result: Option<Res>,
-	/// Error
-	error: Option<String>,
+    /// Error
+    error: Option<String>,
 }
 
 // ---------------- VmTrace ------------------------------

--- a/src/types/traces.rs
+++ b/src/types/traces.rs
@@ -80,6 +80,8 @@ pub struct TransactionTrace {
     action: Action,
     /// Result
     result: Option<Res>,
+	/// Error
+	error: Option<String>,
 }
 
 // ---------------- VmTrace ------------------------------

--- a/src/types/traces.rs
+++ b/src/types/traces.rs
@@ -1,7 +1,7 @@
 //! Types for the Parity Ad-Hoc Trace API
 use std::collections::BTreeMap;
 
-use crate::types::{Action, Bytes, Res, H160, H256, U256};
+use crate::types::{Action, ActionType, Bytes, Res, H160, H256, U256};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize)]
@@ -78,6 +78,9 @@ pub struct TransactionTrace {
     subtraces: usize,
     /// Action
     action: Action,
+    /// Action Type
+    #[serde(rename = "type")]
+    action_type: ActionType,
     /// Result
     result: Option<Res>,
     /// Error


### PR DESCRIPTION
Hey :wave:!

Parity encodes traces results in one of two fields:
- "result" which can either store a `CallResult`, `CreateResult` or be equal to `null` (`Res::None`)
- "error" which stores a `TraceError` (https://github.com/paritytech/parity-ethereum/blob/master/ethcore/trace/src/types/error.rs#L25) and which Parity considers as either a `FailedCall` or `FailedCreate`

Currently, `Res` would only be able to decode a `CallResult`, `CreateResult` or `None` because it would only look into the "result" field. Thus, `FailedCallOrCreate` is unnecessary but `Trace` and `TransactionTrace` need an `error` field (`TransactionTrace` didn't have one).

---

I also added an `action_type` field to `TransactionTrace`.