### PR TITLE
Fixed the "replay_block_transactions" method of api::Traces and added missing fields to BlockTrace

### DIFF
--- a/src/api/traces.rs
+++ b/src/api/traces.rs
@@ -135,17 +135,17 @@ mod tests {
 
     const EXAMPLE_BLOCKTRACES: &'static str = r#"
 	[{
-        "output": "0x010203",
+        "output": "0x",
         "stateDiff": null,
         "trace": [
             {
                 "action": {
                     "callType": "call",
-                    "from": "0x0000000000000000000000000000000000000000",
-                    "gas": "0x1dcd12f8",
+                    "from": "0xa1e4380a3b1f749673e270229993ee55f35663b4",
+                    "gas": "0x0",
                     "input": "0x",
-                    "to": "0x0000000000000000000000000000000000000123",
-                    "value": "0x1"
+                    "to": "0x5df9b87991262f6ba471f09758cde1c0fc1de734",
+                    "value": "0x7a69"
                 },
                 "result": {
                     "gasUsed": "0x0",
@@ -156,6 +156,7 @@ mod tests {
                 "type": "call"
             }
         ],
+        "transactionHash": "0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060",
         "vmTrace": null
     }]
 	"#;

--- a/src/api/traces.rs
+++ b/src/api/traces.rs
@@ -58,12 +58,12 @@ impl<T: Transport> Traces<T> {
         &self,
         block: BlockNumber,
         trace_type: Vec<TraceType>,
-    ) -> CallFuture<BlockTrace, T::Out> {
+    ) -> CallFuture<Vec<BlockTrace>, T::Out> {
         let block = helpers::serialize(&block);
         let trace_type = helpers::serialize(&trace_type);
         CallFuture::new(
             self.transport
-                .execute("trace_replayBlockTransaction", vec![block, trace_type]),
+                .execute("trace_replayBlockTransactions", vec![block, trace_type]),
         )
     }
 
@@ -132,6 +132,33 @@ mod tests {
         "vmTrace": null
     }
     "#;
+
+    const EXAMPLE_BLOCKTRACES: &'static str = r#"
+	[{
+        "output": "0x010203",
+        "stateDiff": null,
+        "trace": [
+            {
+                "action": {
+                    "callType": "call",
+                    "from": "0x0000000000000000000000000000000000000000",
+                    "gas": "0x1dcd12f8",
+                    "input": "0x",
+                    "to": "0x0000000000000000000000000000000000000123",
+                    "value": "0x1"
+                },
+                "result": {
+                    "gasUsed": "0x0",
+                    "output": "0x"
+                },
+                "subtraces": 0,
+                "traceAddress": [],
+                "type": "call"
+            }
+        ],
+        "vmTrace": null
+    }]
+	"#;
 
     const EXAMPLE_TRACE_ARR: &'static str = r#"
     [
@@ -214,9 +241,9 @@ mod tests {
     rpc_test!(
     Traces:replay_block_transactions, BlockNumber::Latest, vec![TraceType::Trace]
     =>
-    "trace_replayBlockTransaction", vec![r#""latest""#, r#"["trace"]"#];
-    ::serde_json::from_str(EXAMPLE_BLOCKTRACE).unwrap()
-    => ::serde_json::from_str::<BlockTrace>(EXAMPLE_BLOCKTRACE).unwrap()
+    "trace_replayBlockTransactions", vec![r#""latest""#, r#"["trace"]"#];
+    ::serde_json::from_str(EXAMPLE_BLOCKTRACES).unwrap()
+    => ::serde_json::from_str::<Vec<BlockTrace>>(EXAMPLE_BLOCKTRACES).unwrap()
     );
 
     rpc_test!(

--- a/src/types/example-traces-str.rs
+++ b/src/types/example-traces-str.rs
@@ -1,0 +1,68 @@
+r#"[{
+  "output": "0x",
+  "stateDiff": {
+	"0x5df9b87991262f6ba471f09758cde1c0fc1de734": {
+	  "balance": {
+		"+": "0x7a69"
+	  },
+	  "code": {
+		"+": "0x"
+	  },
+	  "nonce": {
+		"+": "0x0"
+	  },
+	  "storage": {}
+	},
+	"0xa1e4380a3b1f749673e270229993ee55f35663b4": {
+	  "balance": {
+		"*": {
+		  "from": "0x6c6b935b8bbd400000",
+		  "to": "0x6c5d01021be7168597"
+		}
+	  },
+	  "code": "=",
+	  "nonce": {
+		"*": {
+		  "from": "0x0",
+		  "to": "0x1"
+		}
+	  },
+	  "storage": {}
+	},
+	"0xe6a7a1d47ff21b6321162aea7c6cb457d5476bca": {
+	  "balance": {
+		"*": {
+		  "from": "0xf3426785a8ab466000",
+		  "to": "0xf350f9df18816f6000"
+		}
+	  },
+	  "code": "=",
+	  "nonce": "=",
+	  "storage": {}
+	}
+  },
+  "trace": [
+	{
+	  "action": {
+		"callType": "call",
+		"from": "0xa1e4380a3b1f749673e270229993ee55f35663b4",
+		"gas": "0x0",
+		"input": "0x",
+		"to": "0x5df9b87991262f6ba471f09758cde1c0fc1de734",
+		"value": "0x7a69"
+	  },
+	  "result": {
+		"gasUsed": "0x0",
+		"output": "0x"
+	  },
+	  "subtraces": 0,
+	  "traceAddress": [],
+	  "type": "call"
+	}
+  ],
+  "transactionHash": "0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060",
+  "vmTrace": {
+	"code": "0x",
+	"ops": []
+  }
+}]"#

--- a/src/types/traces.rs
+++ b/src/types/traces.rs
@@ -150,6 +150,11 @@ mod tests {
     // with 'trace', 'vmTrace', 'stateDiff'
     const EXAMPLE_TRACE: &'static str = include!("./example-trace-str.rs");
 
+    // block: https://etherscan.io/block/46147
+    // using the 'trace_replayBlockTransactions' API function
+    // with 'trace', 'vmTrace', 'stateDiff'
+    const EXAMPLE_TRACES: &'static str = include!("./example-traces-str.rs");
+
     #[test]
     fn test_serialize_trace_type() {
         let trace_type_str = r#"["trace","vmTrace","stateDiff"]"#;
@@ -162,5 +167,10 @@ mod tests {
     #[test]
     fn test_deserialize_blocktrace() {
         let _trace: BlockTrace = serde_json::from_str(EXAMPLE_TRACE).unwrap();
+    }
+
+    #[test]
+    fn test_deserialize_blocktraces() {
+        let _traces: Vec<BlockTrace> = serde_json::from_str(EXAMPLE_TRACES).unwrap();
     }
 }

--- a/src/types/traces.rs
+++ b/src/types/traces.rs
@@ -31,6 +31,9 @@ pub struct BlockTrace {
     /// State Difference
     #[serde(rename = "stateDiff")]
     pub state_diff: Option<StateDiff>,
+    /// Transaction Hash
+    #[serde(rename = "transactionHash")]
+    pub transaction_hash: Option<H256>,
 }
 
 //---------------- State Diff ----------------


### PR DESCRIPTION
Hey :wave:!

The method was calling "trace_replayBlockTransaction" instead of "trace_replayBlockTransactions" (missing "s" at the end) and was returning a single BlockTrace instead of a vector of them (https://wiki.parity.io/JSONRPC-trace-module.html#trace_replayblocktransactions).

Tests were also added for both the method (using the block 46147) and deserialization of vectors of BlockTrace.

It fixes the RPC API part of #203 and I tried decoding the output that the OP gave and apart from a `,"id":0}` at the end that shouldn't have been there, everything was fine.

NOTE: the block I chose isn't the best possible so feel free to suggest change it (beware of the size of the JSON though).

---

I also added a `transaction_hash` field to `BlockTrace` which is returned by Parity when calling "trace_replayBlockTransactions".