### PR TITLE
Custom signing methods

### DIFF
--- a/src/api/accounts.rs
+++ b/src/api/accounts.rs
@@ -54,12 +54,14 @@ impl<T: Transport> Accounts<T> {
     /// using keccak256.
     pub fn hash_message<S>(&self, message: S) -> H256
     where
-        S: AsRef<str>,
+        S: AsRef<[u8]>,
     {
         let message = message.as_ref();
-        let eth_message = format!("\x19Ethereum Signed Message:\n{}{}", message.len(), message);
 
-        eth_message.as_bytes().keccak256().into()
+        let mut eth_message = Vec::from(format!("\x19Ethereum Signed Message:\n{}", message.len()).as_bytes());
+        eth_message.extend_from_slice(message);
+
+        eth_message.keccak256().into()
     }
 
     /// Sign arbitrary string data.
@@ -72,10 +74,10 @@ impl<T: Transport> Accounts<T> {
     /// such as `ethsign`.
     pub fn sign<S>(&self, message: S, key: &SecretKey) -> Result<SignedData, Error>
     where
-        S: AsRef<str>,
+        S: AsRef<[u8]>,
     {
-        let message = message.as_ref().to_string();
-        let message_hash = self.hash_message(&message);
+        let message = message.as_ref();
+        let message_hash = self.hash_message(message);
 
         let signature = key.sign(&message_hash[..]).map_err(EthsignError::from)?;
         // convert to 'Electrum' notation
@@ -88,6 +90,9 @@ impl<T: Transport> Accounts<T> {
             bytes.push(v);
             bytes
         });
+
+        // We perform this allocation only after all previous fallible action have completed successfully.
+        let message = message.to_owned();
 
         Ok(SignedData {
             message,
@@ -109,7 +114,7 @@ impl<T: Transport> Accounts<T> {
     {
         let recovery = recovery.into();
         let message_hash = match recovery.message {
-            RecoveryMessage::String(ref message) => self.hash_message(message),
+            RecoveryMessage::Bytes(ref message) => self.hash_message(message),
             RecoveryMessage::Hash(hash) => hash,
         };
         let signature = recovery.as_signature();

--- a/src/api/accounts.rs
+++ b/src/api/accounts.rs
@@ -91,7 +91,7 @@ impl<T: Transport> Accounts<T> {
             bytes
         });
 
-        // We perform this allocation only after all previous fallible action have completed successfully.
+        // We perform this allocation only after all previous fallible actions have completed successfully.
         let message = message.to_owned();
 
         Ok(SignedData {

--- a/src/api/accounts.rs
+++ b/src/api/accounts.rs
@@ -114,7 +114,7 @@ impl<T: Transport> Accounts<T> {
     {
         let recovery = recovery.into();
         let message_hash = match recovery.message {
-            RecoveryMessage::Bytes(ref message) => self.hash_message(message),
+            RecoveryMessage::Data(ref message) => self.hash_message(message),
             RecoveryMessage::Hash(hash) => hash,
         };
         let signature = recovery.as_signature();

--- a/src/types/recovery.rs
+++ b/src/types/recovery.rs
@@ -111,7 +111,7 @@ impl<'a> From<&'a EthtxSignedTransaction<'a>> for Recovery {
 #[derive(Clone, Debug, PartialEq)]
 pub enum RecoveryMessage {
     /// Message bytes
-    Bytes(Vec<u8>),
+    Data(Vec<u8>),
     /// Message hash
     Hash(H256),
 }
@@ -125,7 +125,7 @@ impl From<&[u8]> for RecoveryMessage {
 
 impl From<Vec<u8>> for RecoveryMessage {
     fn from(s: Vec<u8>) -> Self {
-        RecoveryMessage::Bytes(s)
+        RecoveryMessage::Data(s)
     }
 }
 
@@ -137,7 +137,7 @@ impl From<&str> for RecoveryMessage {
 
 impl From<String> for RecoveryMessage {
     fn from(s: String) -> Self {
-        RecoveryMessage::Bytes(s.into_bytes())
+        RecoveryMessage::Data(s.into_bytes())
     }
 }
 

--- a/src/types/recovery.rs
+++ b/src/types/recovery.rs
@@ -105,26 +105,39 @@ impl<'a> From<&'a EthtxSignedTransaction<'a>> for Recovery {
 
 /// Recovery message data.
 ///
-/// The message data can either be a string message that is first hashed
+/// The message data can either be a binary message that is first hashed
 /// according to EIP-191 and then recovered based on the signature or a
 /// precomputed hash.
 #[derive(Clone, Debug, PartialEq)]
 pub enum RecoveryMessage {
-    /// Message string
-    String(String),
+    /// Message bytes
+    Bytes(Vec<u8>),
     /// Message hash
     Hash(H256),
 }
 
-impl<'a> From<&'a str> for RecoveryMessage {
-    fn from(s: &'a str) -> Self {
+impl From<&[u8]> for RecoveryMessage {
+    fn from(s: &[u8]) -> Self {
         s.to_owned().into()
+    }
+}
+
+
+impl From<Vec<u8>> for RecoveryMessage {
+    fn from(s: Vec<u8>) -> Self {
+        RecoveryMessage::Bytes(s)
+    }
+}
+
+impl From<&str> for RecoveryMessage {
+    fn from(s: &str) -> Self {
+        s.as_bytes().to_owned().into()
     }
 }
 
 impl From<String> for RecoveryMessage {
     fn from(s: String) -> Self {
-        RecoveryMessage::String(s)
+        RecoveryMessage::Bytes(s.into_bytes())
     }
 }
 
@@ -170,7 +183,7 @@ mod tests {
             .unwrap();
 
         let signed = SignedData {
-            message: message.to_string(),
+            message: message.as_bytes().to_owned(),
             message_hash: "1da44b586eb0729ff70a73c326926f6ed5a25f5b056e7f47fbc6e58d86871655"
                 .parse()
                 .unwrap(),

--- a/src/types/recovery.rs
+++ b/src/types/recovery.rs
@@ -122,7 +122,6 @@ impl From<&[u8]> for RecoveryMessage {
     }
 }
 
-
 impl From<Vec<u8>> for RecoveryMessage {
     fn from(s: Vec<u8>) -> Self {
         RecoveryMessage::Data(s)

--- a/src/types/signed.rs
+++ b/src/types/signed.rs
@@ -22,7 +22,7 @@ pub struct SignedData {
 /// Transaction data for signing.
 ///
 /// The `Accounts::sign_transaction` method will fill optional fields with sane
-/// defaults when they are ommited. Specifically the signing account's current
+/// defaults when they are omitted. Specifically the signing account's current
 /// transaction count will be used for the `nonce`, the estimated recommended
 /// gas price will be used for `gas_price`, and the current network ID will be
 /// used for the `chain_id`.

--- a/src/types/signed.rs
+++ b/src/types/signed.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 /// Struct representing signed data returned from `Accounts::sign` method.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct SignedData {
-    /// The original method that was signed.
-    pub message: String,
+    /// The original message that was signed.
+    pub message: Vec<u8>,
     /// The keccak256 hash of the signed data.
     #[serde(rename = "messageHash")]
     pub message_hash: H256,


### PR DESCRIPTION
This is a follow up PR to the ideas in [this comment](https://github.com/tomusdrw/rust-web3/pull/279#issuecomment-554799367) on #279. 

I define equivalents of methods that call functions on secret contracts, but i sign the transactions locally instead of letting the ethereum node sign them for me with an unlocked account.

The first commit addresses the issue pointed out in [this comment](https://github.com/tomusdrw/rust-web3/pull/279#discussion_r347868904) (Signing should accept arbitrary binary data rather than only UTF-8 data.)