### PR TITLE
estimate_gas: do not serialize null block number

### DIFF
--- a/src/api/eth.rs
+++ b/src/api/eth.rs
@@ -73,12 +73,9 @@ impl<T: Transport> Eth<T> {
     pub fn estimate_gas(&self, req: CallRequest, block: Option<BlockNumber>) -> CallFuture<U256, T::Out> {
         let req = helpers::serialize(&req);
 
-        let args = {
-            if let Some(block) = block {
-                vec![req, helpers::serialize(&block)]
-            } else {
-                vec![req]
-            }
+        let args = match block {
+            Some(block) => vec![req, helpers::serialize(&block)],
+            None => vec![req],
         };
 
         CallFuture::new(self.transport.execute("eth_estimateGas", args))

--- a/src/api/eth.rs
+++ b/src/api/eth.rs
@@ -463,6 +463,17 @@ mod tests {
   );
 
     rpc_test! (
+    Eth:estimate_gas:for_block, CallRequest {
+      from: None, to: Address::from_low_u64_be(0x123),
+      gas: None, gas_price: None,
+      value: Some(0x1.into()), data: None,
+    }, Some(0x123.into())
+    =>
+    "eth_estimateGas", vec![r#"{"to":"0x0000000000000000000000000000000000000123","value":"0x1"}"#, r#""0x123""#];
+    Value::String("0x123".into()) => 0x123
+  );
+
+    rpc_test! (
     Eth:gas_price => "eth_gasPrice";
     Value::String("0x123".into()) => 0x123
   );

--- a/src/api/eth.rs
+++ b/src/api/eth.rs
@@ -72,9 +72,16 @@ impl<T: Transport> Eth<T> {
     /// Call a contract without changing the state of the blockchain to estimate gas usage.
     pub fn estimate_gas(&self, req: CallRequest, block: Option<BlockNumber>) -> CallFuture<U256, T::Out> {
         let req = helpers::serialize(&req);
-        let block = helpers::serialize(&block.unwrap_or(BlockNumber::Latest));
 
-        CallFuture::new(self.transport.execute("eth_estimateGas", vec![req, block]))
+        let args = {
+            if let Some(block) = block {
+                vec![req, helpers::serialize(&block)]
+            } else {
+                vec![req]
+            }
+        };
+
+        CallFuture::new(self.transport.execute("eth_estimateGas", args))
     }
 
     /// Get current recommended gas price
@@ -454,7 +461,7 @@ mod tests {
       value: Some(0x1.into()), data: None,
     }, None
     =>
-    "eth_estimateGas", vec![r#"{"to":"0x0000000000000000000000000000000000000123","value":"0x1"}"#, r#""latest""#];
+    "eth_estimateGas", vec![r#"{"to":"0x0000000000000000000000000000000000000123","value":"0x1"}"#];
     Value::String("0x123".into()) => 0x123
   );
 

--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -362,7 +362,7 @@ mod tests {
         };
 
         // then
-        transport.assert_request("eth_estimateGas", &["{\"data\":\"0x06fdde03\",\"from\":\"0x0000000000000000000000000000000000000005\",\"to\":\"0x0000000000000000000000000000000000000001\"}".into(), "\"latest\"".into()]);
+        transport.assert_request("eth_estimateGas", &["{\"data\":\"0x06fdde03\",\"from\":\"0x0000000000000000000000000000000000000005\",\"to\":\"0x0000000000000000000000000000000000000001\"}".into()]);
         transport.assert_no_more_requests();
         assert_eq!(result, 5.into());
     }


### PR DESCRIPTION
Do not serialise second argument (block number) if it's null. This is a workaround for ethereum/go-ethereum#2586. Fixes #290.