### PR TITLE
Implement `parity` namespace

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -4,6 +4,7 @@ mod eth;
 mod eth_filter;
 mod eth_subscribe;
 mod net;
+mod parity;
 mod parity_accounts;
 mod parity_set;
 mod personal;
@@ -14,6 +15,7 @@ pub use self::eth::Eth;
 pub use self::eth_filter::{BaseFilter, CreateFilter, EthFilter, FilterStream};
 pub use self::eth_subscribe::{EthSubscribe, SubscriptionId, SubscriptionResult, SubscriptionStream};
 pub use self::net::Net;
+pub use self::parity::Parity;
 pub use self::parity_accounts::ParityAccounts;
 pub use self::parity_set::ParitySet;
 pub use self::personal::Personal;
@@ -75,6 +77,9 @@ impl<T: Transport> Web3<T> {
     pub fn eth_filter(&self) -> eth_filter::EthFilter<T> {
         self.api()
     }
+
+    /// Access methods from `parity` namespace
+    pub fn parity(&self) -> parity::Parity<T> { self.api() }
 
     /// Access methods from `parity_accounts` namespace
     pub fn parity_accounts(&self) -> parity_accounts::ParityAccounts<T> {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -79,7 +79,9 @@ impl<T: Transport> Web3<T> {
     }
 
     /// Access methods from `parity` namespace
-    pub fn parity(&self) -> parity::Parity<T> { self.api() }
+    pub fn parity(&self) -> parity::Parity<T> {
+        self.api()
+    }
 
     /// Access methods from `parity_accounts` namespace
     pub fn parity_accounts(&self) -> parity_accounts::ParityAccounts<T> {

--- a/src/api/parity.rs
+++ b/src/api/parity.rs
@@ -27,7 +27,7 @@ impl<T: Transport> Namespace<T> for Parity<T> {
 impl<T: Transport> Parity<T> {
     /// Sequentially call multiple contract methods in one request without changing the state of the blockchain.
     pub fn call(&self, reqs: Vec<CallRequest>) -> CallFuture<Vec<Bytes>, T::Out> {
-        let req = helpers::serialize(&reqs);
+        let reqs = helpers::serialize(&reqs);
 
         CallFuture::new(self.transport.execute("parity_call", vec![reqs]))
     }

--- a/src/api/parity.rs
+++ b/src/api/parity.rs
@@ -25,10 +25,11 @@ impl<T: Transport> Namespace<T> for Parity<T> {
 }
 
 impl<T: Transport> Parity<T> {
-    pub fn call(&self, req: Vec<CallRequest>) -> CallFuture<Vec<Bytes>, T::Out> {
-        let req = helpers::serialize(&req);
+    /// Sequentially call multiple contract methods in one request without changing the state of the blockchain.
+    pub fn call(&self, reqs: Vec<CallRequest>) -> CallFuture<Vec<Bytes>, T::Out> {
+        let req = helpers::serialize(&reqs);
 
-        CallFuture::new(self.transport.execute("parity_call", vec![req]))
+        CallFuture::new(self.transport.execute("parity_call", vec![reqs]))
     }
 }
 

--- a/src/api/parity.rs
+++ b/src/api/parity.rs
@@ -1,0 +1,77 @@
+use crate::{
+    api::Namespace,
+    helpers::{self, CallFuture},
+    types::{Address, BlockNumber, Bytes, CallRequest},
+    Transport,
+};
+
+/// `Parity` namespace
+#[derive(Debug, Clone)]
+pub struct Parity<T> {
+    transport: T,
+}
+
+impl<T: Transport> Namespace<T> for Parity<T> {
+    fn new(transport: T) -> Self
+    where
+        Self: Sized,
+    {
+        Parity { transport }
+    }
+
+    fn transport(&self) -> &T {
+        &self.transport
+    }
+}
+
+impl<T: Transport> Parity<T> {
+    pub fn call(&self, req: Vec<CallRequest>) -> CallFuture<Vec<Bytes>, T::Out> {
+        let req = helpers::serialize(&req);
+
+        CallFuture::new(self.transport.execute("parity_call", vec![req]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Parity;
+    use crate::{
+        api::Namespace,
+        rpc::Value,
+        types::{Address, Bytes, CallRequest},
+    };
+    use futures::Future;
+
+    rpc_test!(
+        Parity:call,
+        vec![
+            CallRequest {
+                from: None,
+                to: Address::from_low_u64_be(0x123),
+                gas: None,
+                gas_price: None,
+                value: Some(0x1.into()),
+                data: None,
+            },
+            CallRequest {
+                from: Some(Address::from_low_u64_be(0x321)),
+                to: Address::from_low_u64_be(0x123),
+                gas: None,
+                gas_price: None,
+                value: None,
+                data: Some(Bytes(vec![0x04, 0x93])),
+            },
+            CallRequest {
+                from: None,
+                to: Address::from_low_u64_be(0x765),
+                gas: None,
+                gas_price: None,
+                value: Some(0x5.into()),
+                data: Some(Bytes(vec![0x07, 0x23]))
+            }
+        ] => "parity_call", vec![
+            r#"[{"to":"0x0000000000000000000000000000000000000123","value":"0x1"},{"data":"0x0493","from":"0x0000000000000000000000000000000000000321","to":"0x0000000000000000000000000000000000000123"},{"data":"0x0723","to":"0x0000000000000000000000000000000000000765","value":"0x5"}]"#
+        ];
+        Value::Array(vec![Value::String("0x010203".into()), Value::String("0x7198ab".into()), Value::String("0xde763f".into())]) => vec![Bytes(vec![1, 2, 3]), Bytes(vec![0x71, 0x98, 0xab]), Bytes(vec![0xde, 0x76, 0x3f])]
+    );
+}

--- a/src/api/parity.rs
+++ b/src/api/parity.rs
@@ -1,7 +1,7 @@
 use crate::{
     api::Namespace,
     helpers::{self, CallFuture},
-    types::{Address, BlockNumber, Bytes, CallRequest},
+    types::{Bytes, CallRequest},
     Transport,
 };
 


### PR DESCRIPTION
Do it mostly for very handy `parity_call` [method](https://github.com/paritytech/wiki/blob/master/JSONRPC-parity-module.md#parity_call) that allowing to run sequential `eth_call`s in one request. Also i'm tried to implement a batch version of `web3::contract::Contract::query` method using `parity_call`, but have not yet figured out how.