### PR TITLE
Add root field to transaction receipt

### DIFF
--- a/src/confirm.rs
+++ b/src/confirm.rs
@@ -359,6 +359,7 @@ mod tests {
             contract_address: None,
             logs: vec![],
             status: Some(1.into()),
+            root: Some(H256::zero()),
             logs_bloom: Default::default(),
         };
 

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -62,6 +62,8 @@ pub struct Receipt {
     pub logs: Vec<Log>,
     /// Status: either 1 (success) or 0 (failure).
     pub status: Option<U64>,
+    /// State root.
+    pub root: Option<H256>,
     /// Logs bloom
     #[serde(rename = "logsBloom")]
     pub logs_bloom: H2048,


### PR DESCRIPTION
Corresponding field in OE: https://github.com/openethereum/openethereum/blob/3ccfe735aa579f89a1f8de192a7625084a6f530f/rpc/src/v1/types/receipt.rs#L45

(bridge currently points to my fork of rust-web3 => conflicts when `cargo update`)