### PR TITLE
Make CallRequest's `to` field optional

### DIFF
--- a/src/api/eth.rs
+++ b/src/api/eth.rs
@@ -462,7 +462,7 @@ mod tests {
 
     rpc_test! (
       Eth:call, CallRequest {
-        from: None, to: Address::from_low_u64_be(0x123),
+        from: None, to: Some(Address::from_low_u64_be(0x123)),
         gas: None, gas_price: None,
         value: Some(0x1.into()), data: None,
       }, None
@@ -493,7 +493,7 @@ mod tests {
 
     rpc_test! (
       Eth:estimate_gas, CallRequest {
-        from: None, to: Address::from_low_u64_be(0x123),
+        from: None, to: Some(Address::from_low_u64_be(0x123)),
         gas: None, gas_price: None,
         value: Some(0x1.into()), data: None,
       }, None
@@ -502,9 +502,21 @@ mod tests {
       Value::String("0x123".into()) => 0x123
     );
 
+    // NOTE: I don't know why this is passing
+    rpc_test! (
+      Eth:estimate_gas:optional_to_addr, CallRequest {
+        from: None, to: None,
+        gas: None, gas_price: None,
+        value: Some(0x1.into()), data: None,
+      }, None
+      =>
+      "eth_estimateGas", vec![r#"{"value":"0x1"}"#];
+      Value::String("0x123".into()) => 0x123
+    );
+
     rpc_test! (
       Eth:estimate_gas:for_block, CallRequest {
-        from: None, to: Address::from_low_u64_be(0x123),
+        from: None, to: Some(Address::from_low_u64_be(0x123)),
         gas: None, gas_price: None,
         value: Some(0x1.into()), data: None,
       }, Some(0x123.into())

--- a/src/api/eth.rs
+++ b/src/api/eth.rs
@@ -502,7 +502,6 @@ mod tests {
       Value::String("0x123".into()) => 0x123
     );
 
-    // NOTE: I don't know why this is passing
     rpc_test! (
       Eth:estimate_gas:optional_to_addr, CallRequest {
         from: None, to: None,
@@ -511,7 +510,7 @@ mod tests {
       }, None
       =>
       "eth_estimateGas", vec![r#"{"value":"0x1"}"#];
-      Value::String("0x123".into()) => 0x123
+      Value::String("0x5555".into()) => 0x5555
     );
 
     rpc_test! (

--- a/src/api/parity.rs
+++ b/src/api/parity.rs
@@ -48,7 +48,7 @@ mod tests {
         vec![
             CallRequest {
                 from: None,
-                to: Address::from_low_u64_be(0x123),
+                to: Some(Address::from_low_u64_be(0x123)),
                 gas: None,
                 gas_price: None,
                 value: Some(0x1.into()),
@@ -56,7 +56,7 @@ mod tests {
             },
             CallRequest {
                 from: Some(Address::from_low_u64_be(0x321)),
-                to: Address::from_low_u64_be(0x123),
+                to: Some(Address::from_low_u64_be(0x123)),
                 gas: None,
                 gas_price: None,
                 value: None,
@@ -64,7 +64,7 @@ mod tests {
             },
             CallRequest {
                 from: None,
-                to: Address::from_low_u64_be(0x765),
+                to: Some(Address::from_low_u64_be(0x765)),
                 gas: None,
                 gas_price: None,
                 value: Some(0x5.into()),

--- a/src/api/traces.rs
+++ b/src/api/traces.rs
@@ -213,7 +213,7 @@ mod tests {
 
     rpc_test!(
     Traces:call, CallRequest {
-    from: None, to: Address::from_low_u64_be(0x123),
+    from: None, to: Some(Address::from_low_u64_be(0x123)),
     gas: None, gas_price: None,
     value: Some(0x1.into()), data: None,
     }, vec![TraceType::Trace], None

--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -197,7 +197,7 @@ impl<T: Transport> Contract<T> {
                     .estimate_gas(
                         CallRequest {
                             from: Some(from),
-                            to: self.address,
+                            to: Some(self.address),
                             gas: options.gas,
                             gas_price: options.gas_price,
                             value: options.value,
@@ -236,7 +236,7 @@ impl<T: Transport> Contract<T> {
                 let result = self.eth.call(
                     CallRequest {
                         from: from.into(),
-                        to: self.address,
+                        to: Some(self.address),
                         gas: options.gas,
                         gas_price: options.gas_price,
                         value: options.value,

--- a/src/types/signed.rs
+++ b/src/types/signed.rs
@@ -79,15 +79,9 @@ impl Default for TransactionParameters {
 
 impl From<CallRequest> for TransactionParameters {
     fn from(call: CallRequest) -> Self {
-        let to = if call.to != Address::zero() {
-            Some(call.to)
-        } else {
-            None
-        };
-
         TransactionParameters {
             nonce: None,
-            to,
+            to: call.to,
             gas: call.gas.unwrap_or(TRANSACTION_DEFAULT_GAS),
             gas_price: call.gas_price,
             value: call.value.unwrap_or_default(),
@@ -101,7 +95,7 @@ impl Into<CallRequest> for TransactionParameters {
     fn into(self) -> CallRequest {
         CallRequest {
             from: None,
-            to: self.to.unwrap_or_default(),
+            to: self.to,
             gas: Some(self.gas),
             gas_price: self.gas_price,
             value: Some(self.value),

--- a/src/types/transaction_request.rs
+++ b/src/types/transaction_request.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 /// When using this for `eth_estimateGas`, all the fields
 /// are optional. However, for usage in `eth_call` the
 /// `to` field must be provided.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
 pub struct CallRequest {
     /// Sender address (None for arbitrary address)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -30,7 +30,7 @@ pub struct CallRequest {
 }
 
 /// Send Transaction Parameters
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
 pub struct TransactionRequest {
     /// Sender address
     pub from: Address,

--- a/src/types/transaction_request.rs
+++ b/src/types/transaction_request.rs
@@ -2,13 +2,18 @@ use crate::types::{Address, Bytes, U256};
 use serde::{Deserialize, Serialize};
 
 /// Call contract request (eth_call / eth_estimateGas)
+///
+/// When using this for `eth_estimateGas`, all the fields
+/// are optional. However, for usage in `eth_call` the
+/// `to` field must be provided.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CallRequest {
     /// Sender address (None for arbitrary address)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub from: Option<Address>,
-    /// To address
-    pub to: Address,
+    /// To address (None allowed for eth_estimateGas)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to: Option<Address>,
     /// Supplied gas (None for sensible default)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gas: Option<U256>,
@@ -75,7 +80,7 @@ mod tests {
         // given
         let call_request = CallRequest {
             from: None,
-            to: Address::from_low_u64_be(5),
+            to: Some(Address::from_low_u64_be(5)),
             gas: Some(21_000.into()),
             gas_price: None,
             value: Some(5_000_000.into()),
@@ -108,7 +113,7 @@ mod tests {
         let deserialized: CallRequest = serde_json::from_str(&serialized).unwrap();
 
         assert_eq!(deserialized.from, None);
-        assert_eq!(deserialized.to, Address::from_low_u64_be(5));
+        assert_eq!(deserialized.to, Some(Address::from_low_u64_be(5)));
         assert_eq!(deserialized.gas, Some(21_000.into()));
         assert_eq!(deserialized.gas_price, None);
         assert_eq!(deserialized.value, Some(5_000_000.into()));


### PR DESCRIPTION
According to the Ethereum Wiki [page on JSON-RPC](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_estimategas), the `eth_call` and `eth_estimateGas` calls use the same parameters, with the exception that all the fields for `eth_estimateGas` are optional.

Currently, `CallRequest`'s `to` field was not optional. This PR changes that, making it suitable for use with `eth_estimateGas`.

I have a question about the RPC test I added with a `None` value for `to`. I didn't know what `eth_estimateGas` would return in that case, so I left the response from the test I copied. It passes, but I'm not sure it should considering that `Value::String("0x123".into()) => 0x123` was in reference to the `to` address. What should this test check instead?