### PR TITLE
Add support for wss

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ hyper-tls = { version = "0.4", optional = true }
 native-tls = { version = "0.2", optional = true }
 url = { version = "2.1.0", optional = true }
 ## WS
+async-native-tls = { version = "0.3", optional = true }
 async-std = { version = "1.5.0", optional = true }
 soketto = { version = "0.4.1", optional = true }
 
@@ -50,6 +51,6 @@ async-std = { version = "1.5.0", features = ["attributes"] }
 default = ["http", "ws", "tls"]
 http = ["hyper", "url", "base64"]
 tls = ["hyper-tls", "native-tls"]
-ws = ["soketto", "async-std"]
+ws = ["soketto", "async-std", "async-native-tls"]
 
 [workspace]


### PR DESCRIPTION
Make rust-web3 work with an infura-like endpoint.
For example, `wss://mainnet.infura.io/ws/v3/{PROJECT_ID}`