### PR TITLE
Split TLS features and add docs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,11 @@ script:
   - cargo check
   - cargo build
   - cargo test
+  - cargo check --no-default-features
+  - cargo check --no-default-features --features http
+  - cargo check --no-default-features --features http-tls
+  - cargo check --no-default-features --features ws
+  - cargo check --no-default-features --features ws-tls
 
 after_success: |
   [ $TRAVIS_BRANCH = master ] &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web3"
-version = "0.12.0"
+version = "0.13.0"
 description = "Ethereum JSON-RPC client."
 homepage = "https://github.com/tomusdrw/rust-web3"
 repository = "https://github.com/tomusdrw/rust-web3"
@@ -31,14 +31,15 @@ zeroize = "1.1.0"
 # Optional deps
 ## HTTP
 base64 = { version = "0.12.0", optional = true }
-hyper = { version = "0.13", optional = true }
+hyper = { version = "0.13", optional = true, default-features = false, features = ["stream", "tcp"] }
 hyper-tls = { version = "0.4", optional = true }
-native-tls = { version = "0.2", optional = true }
-url = { version = "2.1.0", optional = true }
 ## WS
 async-native-tls = { version = "0.3", optional = true }
 async-std = { version = "1.5.0", optional = true }
 soketto = { version = "0.4.1", optional = true }
+## Shared (WS, HTTP)
+native-tls = { version = "0.2", optional = true }
+url = { version = "2.1.0", optional = true }
 
 [dev-dependencies]
 # For examples
@@ -48,9 +49,10 @@ tokio = { version = "0.2", features = ["full"] }
 async-std = { version = "1.5.0", features = ["attributes"] }
 
 [features]
-default = ["http", "ws", "tls"]
+default = ["http", "ws", "http-tls", "ws-tls"]
 http = ["hyper", "url", "base64"]
-tls = ["hyper-tls", "native-tls"]
-ws = ["soketto", "async-std", "async-native-tls"]
+http-tls = ["hyper-tls", "native-tls", "http"]
+ws = ["soketto", "async-std", "url"]
+ws-tls = ["async-native-tls", "native-tls", "ws"]
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ The solidity compiler is generating the binary and abi code for the smart contra
 
 For more see [examples folder](./examples).
 
+# Opt-out Features
+- `http` - Enables HTTP transport (requires `tokio` runtime, because of `hyper`).
+- `http-tls` - Enables TLS support for HTTP transport (implies `http`).
+- `ws` - Enables WS transport.
+- `ws-tls` - Enables TLS support for WS transport (implies `ws`).
+
 ## Futures migration
 - [ ] Get rid of parking_lot (replace with async-aware locks if really needed).
 - [ ] Consider getting rid of `Unpin` requirements. (#361)

--- a/src/transports/http.rs
+++ b/src/transports/http.rs
@@ -34,19 +34,6 @@ impl From<hyper::header::InvalidHeaderValue> for Error {
     }
 }
 
-impl From<url::ParseError> for Error {
-    fn from(err: url::ParseError) -> Self {
-        Error::Transport(format!("{:?}", err))
-    }
-}
-
-#[cfg(feature = "tls")]
-impl From<native_tls::Error> for Error {
-    fn from(err: native_tls::Error) -> Self {
-        Error::Transport(format!("{:?}", err))
-    }
-}
-
 // The max string length of a request without transfer-encoding: chunked.
 const MAX_SINGLE_CHUNK: usize = 256;
 
@@ -56,18 +43,18 @@ pub struct Http {
     id: Arc<AtomicUsize>,
     url: hyper::Uri,
     basic_auth: Option<HeaderValue>,
-    #[cfg(feature = "tls")]
+    #[cfg(feature = "http-tls")]
     client: hyper::Client<hyper_tls::HttpsConnector<hyper::client::HttpConnector>>,
-    #[cfg(not(feature = "tls"))]
+    #[cfg(not(feature = "http-tls"))]
     client: hyper::Client<hyper::client::HttpConnector>,
 }
 
 impl Http {
     /// Create new HTTP transport connecting to given URL.
     pub fn new(url: &str) -> error::Result<Self> {
-        #[cfg(feature = "tls")]
+        #[cfg(feature = "http-tls")]
         let client = hyper::Client::builder().build::<_, hyper::Body>(hyper_tls::HttpsConnector::new());
-        #[cfg(not(feature = "tls"))]
+        #[cfg(not(feature = "http-tls"))]
         let client = hyper::Client::new();
 
         let basic_auth = {

--- a/src/transports/mod.rs
+++ b/src/transports/mod.rs
@@ -14,3 +14,17 @@ pub use self::http::Http;
 pub mod ws;
 #[cfg(feature = "ws")]
 pub use self::ws::WebSocket;
+
+#[cfg(feature = "url")]
+impl From<url::ParseError> for crate::Error {
+    fn from(err: url::ParseError) -> Self {
+        crate::Error::Transport(format!("{:?}", err))
+    }
+}
+
+#[cfg(feature = "native-tls")]
+impl From<native_tls::Error> for crate::Error {
+    fn from(err: native_tls::Error) -> Self {
+        crate::Error::Transport(format!("{:?}", err))
+    }
+}


### PR DESCRIPTION
Documents the features (and their requirements, like using `tokio` as a runtime for `hyper`) and splits the `tls` from base transport features. Also adds a CI step to check feature compilation in isolation.

Closes #362