### PR TITLE
Add Transaction::raw field

### DIFF
--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -30,6 +30,9 @@ pub struct Transaction {
     pub gas: U256,
     /// Input data
     pub input: Bytes,
+    /// Raw transaction data
+    #[serde(default)]
+    pub raw: Option<Bytes>,
 }
 
 /// "Receipt" of an executed transaction: details of its execution.


### PR DESCRIPTION
Corresponding OE type: https://github.com/openethereum/openethereum/blob/master/rpc/src/v1/types/transaction.rs#L57

I'm not sure whether it should be mandatory (i.e. `raw: Bytes`), or optional field (`raw: Option<Bytes>`). I haven't found this field in official [ethereum RPC wiki](https://eth.wiki/json-rpc/API) in `eth_getTransactionByHash` method description. So even though OE seems to always return this field, I've made it optional.