### PR TITLE
remove unused generic from call_with_confirmations

### DIFF
--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -201,7 +201,7 @@ impl<T: Transport> Contract<T> {
     }
 
     /// Execute a contract function and wait for confirmations
-    pub fn call_with_confirmations<P>(
+    pub fn call_with_confirmations(
         &self,
         func: &str,
         params: impl Tokenize,


### PR DESCRIPTION
`<P>` is not used anywhere as we use `impl Tokenize` instead.
This prevents compilation.