### PR TITLE
Fix net_version doc string

### DIFF
--- a/src/api/net.rs
+++ b/src/api/net.rs
@@ -26,7 +26,7 @@ impl<T: Transport> Namespace<T> for Net<T> {
 }
 
 impl<T: Transport> Net<T> {
-    /// Returns protocol version
+    /// Returns the network id.
     pub fn version(&self) -> CallFuture<String, T::Out> {
         CallFuture::new(self.transport.execute("net_version", vec![]))
     }


### PR DESCRIPTION
See https://eth.wiki/json-rpc/API#net_version . This method returns the network id, not the protocol version (which is returned by `eth_protocolVersion`).