### PR TITLE
Update implementation of Tokenizable for Vec<u8>

### DIFF
--- a/src/contract/tokens.rs
+++ b/src/contract/tokens.rs
@@ -439,8 +439,8 @@ impl_fixed_types!(1024);
 #[cfg(test)]
 mod tests {
     use super::{Detokenize, Tokenizable};
-    use crate::types::{Address, U256};
-    use ethabi::Token;
+    use crate::types::{Address, BytesArray, U256};
+    use ethabi::{Token, Uint};
 
     fn output<R: Detokenize>() -> R {
         unimplemented!()
@@ -455,6 +455,7 @@ mod tests {
         let _string: String = output();
         let _bool: bool = output();
         let _bytes: Vec<u8> = output();
+        let _bytes_array: BytesArray = output();
 
         let _pair: (U256, bool) = output();
         let _vec: Vec<U256> = output();
@@ -485,6 +486,14 @@ mod tests {
         assert_eq!(data[1][0], 2);
         assert_eq!(data[2][0], 3);
         assert_eq!(data[7][0], 8);
+    }
+
+    #[test]
+    fn should_decode_array_of_bytes() {
+        let token = Token::Array(vec![Token::Uint(Uint::from(0)), Token::Uint(Uint::from(1))]);
+        let data: BytesArray = Tokenizable::from_token(token).unwrap();
+        assert_eq!(data.0[0], 0);
+        assert_eq!(data.0[1], 1);
     }
 
     #[test]

--- a/src/types/bytes_array.rs
+++ b/src/types/bytes_array.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
-/// Array of bytes wrapper
+/// A wrapper type for array of bytes.
+/// 
+/// Implements `Tokenizable` so can be used to retrieve data from `Solidity` contracts returning `byte8[]`.
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Hash, Serialize)]
 pub struct BytesArray(pub Vec<u8>);

--- a/src/types/bytes_array.rs
+++ b/src/types/bytes_array.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// A wrapper type for array of bytes.
-/// 
+///
 /// Implements `Tokenizable` so can be used to retrieve data from `Solidity` contracts returning `byte8[]`.
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Hash, Serialize)]
 pub struct BytesArray(pub Vec<u8>);

--- a/src/types/bytes_array.rs
+++ b/src/types/bytes_array.rs
@@ -1,0 +1,5 @@
+use serde::{Deserialize, Serialize};
+
+/// Array of bytes wrapper
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Hash, Serialize)]
+pub struct BytesArray(pub Vec<u8>);

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -2,6 +2,7 @@
 
 mod block;
 mod bytes;
+mod bytes_array;
 mod log;
 mod parity_peers;
 mod recovery;
@@ -17,6 +18,7 @@ mod work;
 
 pub use self::block::{Block, BlockHeader, BlockId, BlockNumber};
 pub use self::bytes::Bytes;
+pub use self::bytes_array::BytesArray;
 pub use self::log::{Filter, FilterBuilder, Log};
 pub use self::parity_peers::{
     EthProtocolInfo, ParityPeerInfo, ParityPeerType, PeerNetworkInfo, PeerProtocolsInfo, PipProtocolInfo,


### PR DESCRIPTION
The contract call could return `uint8[]` instead of `bytes`, but `Vec<u8>` implementation just supports `bytes`.