### PR TITLE
Convert transaction signing to `async`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web3"
-version = "0.13.0"
+version = "0.14.0"
 description = "Ethereum JSON-RPC client."
 homepage = "https://github.com/tomusdrw/rust-web3"
 repository = "https://github.com/tomusdrw/rust-web3"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -13,7 +13,7 @@ mod traces;
 mod txpool;
 mod web3;
 
-pub use self::accounts::{Accounts, SignTransactionFuture};
+pub use self::accounts::Accounts;
 pub use self::eth::Eth;
 pub use self::eth_filter::{BaseFilter, CreateFilter, EthFilter, FilterStream};
 pub use self::eth_subscribe::{EthSubscribe, SubscriptionId, SubscriptionResult, SubscriptionStream};

--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -153,51 +153,45 @@ impl<T: Transport> Contract<T> {
     }
 
     /// Execute a signed contract function and wait for confirmations
-    pub fn signed_call_with_confirmations<'a>(
-        &'a self,
-        func: &'a str,
+    pub async fn signed_call_with_confirmations(
+        &self,
+        func: &str,
         params: impl Tokenize,
         options: Options,
         confirmations: usize,
-        key: impl signing::Key + 'a,
-    ) -> impl Future<Output = crate::Result<TransactionReceipt>> + 'a {
+        key: impl signing::Key,
+    ) -> crate::Result<TransactionReceipt> {
         let poll_interval = time::Duration::from_secs(1);
 
-        self.abi
+        let fn_data = self
+            .abi
             .function(func)
             .and_then(|function| function.encode_input(&params.into_tokens()))
-            .map(move |fn_data| {
-                let accounts = Accounts::new(self.eth.transport().clone());
-                let mut tx = TransactionParameters {
-                    nonce: options.nonce,
-                    to: Some(self.address),
-                    gas_price: options.gas_price,
-                    data: Bytes(fn_data),
-                    ..Default::default()
-                };
-                if let Some(gas) = options.gas {
-                    tx.gas = gas;
-                }
-                if let Some(value) = options.value {
-                    tx.value = value;
-                }
-                let sign_future = accounts.sign_transaction(tx, key);
-
-                Either::Left(sign_future.and_then(move |signed| {
-                    confirm::send_raw_transaction_with_confirmation(
-                        self.eth.transport().clone(),
-                        signed.raw_transaction,
-                        poll_interval,
-                        confirmations,
-                    )
-                }))
-            })
-            .unwrap_or_else(|e| {
-                // TODO [ToDr] SendTransactionWithConfirmation should support custom error type (so that we can return
-                // `contract::Error` instead of more generic `Error`.
-                let err = crate::error::Error::Decoder(format!("{:?}", e));
-                Either::Right(future::ready(Err(err)))
-            })
+            // TODO [ToDr] SendTransactionWithConfirmation should support custom error type (so that we can return
+            // `contract::Error` instead of more generic `Error`.
+            .map_err(|err| crate::error::Error::Decoder(format!("{:?}", err)))?;
+        let accounts = Accounts::new(self.eth.transport().clone());
+        let mut tx = TransactionParameters {
+            nonce: options.nonce,
+            to: Some(self.address),
+            gas_price: options.gas_price,
+            data: Bytes(fn_data),
+            ..Default::default()
+        };
+        if let Some(gas) = options.gas {
+            tx.gas = gas;
+        }
+        if let Some(value) = options.value {
+            tx.value = value;
+        }
+        let signed = accounts.sign_transaction(tx, key).await?;
+        confirm::send_raw_transaction_with_confirmation(
+            self.eth.transport().clone(),
+            signed.raw_transaction,
+            poll_interval,
+            confirmations,
+        )
+        .await
     }
 
     /// Execute a contract function and wait for confirmations


### PR DESCRIPTION
Converting the manual Future implementation to async makes the code
simpler and no longer require Unpin.

part of  #361