### PR TITLE
Convert contract::deploy to async

### DIFF
--- a/examples/contract.rs
+++ b/examples/contract.rs
@@ -23,7 +23,6 @@ async fn main() -> web3::contract::Result<()> {
             (U256::from(1_000_000_u64), "My Token".to_owned(), 3u64, "MT".to_owned()),
             my_account,
         )
-        .expect("Correct parameters are passed to the constructor.")
         .await?;
 
     let result = contract.query("balanceOf", (my_account,), None, Options::default(), None);

--- a/examples/contract_log_filter.rs
+++ b/examples/contract_log_filter.rs
@@ -18,7 +18,7 @@ async fn main() -> web3::contract::Result<()> {
         .confirmations(1)
         .poll_interval(time::Duration::from_secs(10))
         .options(Options::with(|opt| opt.gas = Some(3_000_000.into())))
-        .execute(bytecode, (), accounts[0])?
+        .execute(bytecode, (), accounts[0])
         .await?;
 
     println!("contract deployed at: {}", contract.address());

--- a/examples/contract_log_pubsub.rs
+++ b/examples/contract_log_pubsub.rs
@@ -18,7 +18,7 @@ async fn main() -> web3::contract::Result<()> {
         .confirmations(1)
         .poll_interval(time::Duration::from_secs(10))
         .options(Options::with(|opt| opt.gas = Some(3_000_000.into())))
-        .execute(bytecode, (), accounts[0])?;
+        .execute(bytecode, (), accounts[0]);
     let contract = contract.await?;
     println!("contract deployed at: {}", contract.address());
 

--- a/examples/contract_storage.rs
+++ b/examples/contract_storage.rs
@@ -23,7 +23,7 @@ async fn main() -> web3::contract::Result<()> {
         .confirmations(1)
         .poll_interval(time::Duration::from_secs(10))
         .options(Options::with(|opt| opt.gas = Some(3_000_000.into())))
-        .execute(bytecode, (), accounts[0])?
+        .execute(bytecode, (), accounts[0])
         .await?;
 
     println!("Deployed at: {}", contract.address());

--- a/src/contract/error.rs
+++ b/src/contract/error.rs
@@ -41,6 +41,9 @@ pub mod deploy {
     /// Contract deployment error.
     #[derive(Debug, Display, From)]
     pub enum Error {
+        /// eth abi error
+        #[display(fmt = "Abi error: {}", _0)]
+        Abi(ethabi::Error),
         /// Rpc error
         #[display(fmt = "Api error: {}", _0)]
         Api(ApiError),
@@ -52,6 +55,7 @@ pub mod deploy {
     impl std::error::Error for Error {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
             match *self {
+                Error::Abi(ref e) => Some(e),
                 Error::Api(ref e) => Some(e),
                 Error::ContractDeploymentFailure(_) => None,
             }


### PR DESCRIPTION
part of #361

Note that I have changed `execute` to return a single Result instead of nested Results by extending `deploy::Error` with AbiError.