### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/api/eth.rs
+++ b/src/api/eth.rs
@@ -41,7 +41,7 @@ impl<T: Transport> Eth<T> {
     /// Call a constant method of contract without changing the state of the blockchain.
     pub fn call(&self, req: CallRequest, block: Option<BlockId>) -> CallFuture<Bytes, T::Out> {
         let req = helpers::serialize(&req);
-        let block = helpers::serialize(&block.unwrap_or(BlockNumber::Latest.into()));
+        let block = helpers::serialize(&block.unwrap_or_else(|| BlockNumber::Latest.into()));
 
         CallFuture::new(self.transport.execute("eth_call", vec![req, block]))
     }
@@ -342,7 +342,7 @@ mod tests {
     use super::Eth;
 
     // taken from RPC docs.
-    const EXAMPLE_BLOCK: &'static str = r#"{
+    const EXAMPLE_BLOCK: &str = r#"{
     "number": "0x1b4",
     "hash": "0x0e670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331",
     "parentHash": "0x9646252be9520f6e71339a8df9c55e4d7619deeb018d2a3f2d21fc165dde5eb5",
@@ -371,7 +371,7 @@ mod tests {
   }"#;
 
     // response from RPC request {"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["pending", false],"id":1}.
-    const EXAMPLE_PENDING_BLOCK: &'static str = r#"{
+    const EXAMPLE_PENDING_BLOCK: &str = r#"{
         "author": "0x0000000000000000000000000000000000000000",
         "difficulty": "0x7eac2e8c440b2",
         "extraData": "0xde830207028f5061726974792d457468657265756d86312e34312e30826c69",
@@ -408,7 +408,7 @@ mod tests {
     // taken from RPC docs, but with leading `00` added to `blockHash`
     // and `transactionHash` fields because RPC docs currently show
     // 31-byte values in both positions (must be 32 bytes).
-    const EXAMPLE_LOG: &'static str = r#"{
+    const EXAMPLE_LOG: &str = r#"{
     "logIndex": "0x1",
     "blockNumber":"0x1b4",
     "blockHash": "0x008216c5785ac562ff41e2dcfdf5785ac562ff41e2dcfdf829c5a142f1fccd7d",
@@ -420,7 +420,7 @@ mod tests {
   }"#;
 
     // taken from RPC docs.
-    const EXAMPLE_TX: &'static str = r#"{
+    const EXAMPLE_TX: &str = r#"{
     "hash": "0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b",
     "nonce": "0x0",
     "blockHash": "0xbeab0aa2411b7ab17f30a99d3cb9c6ef2fc5426d6ad6fd9e2a26a6aed1d1055b",
@@ -435,7 +435,7 @@ mod tests {
   }"#;
 
     // taken from RPC docs.
-    const EXAMPLE_RECEIPT: &'static str = r#"{
+    const EXAMPLE_RECEIPT: &str = r#"{
     "hash": "0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238",
     "index": "0x1",
     "transactionHash": "0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238",

--- a/src/api/eth_filter.rs
+++ b/src/api/eth_filter.rs
@@ -48,7 +48,7 @@ impl<T: Transport, I> FilterStream<T, I> {
     fn new(base: BaseFilter<T, I>, poll_interval: Duration) -> Self {
         FilterStream {
             base,
-            poll_interval: poll_interval.clone(),
+            poll_interval,
             interval: Box::new(interval(poll_interval)),
             state: FilterStreamState::WaitForInterval,
         }
@@ -283,15 +283,12 @@ impl<T: Transport> EthFilter<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::rpc::Value;
-    use serde_json;
-    use std::time::Duration;
-
+    use super::EthFilter;
     use crate::api::Namespace;
     use crate::helpers::tests::TestTransport;
+    use crate::rpc::Value;
     use crate::types::{Address, Bytes, FilterBuilder, Log, H256};
-
-    use super::EthFilter;
+    use std::time::Duration;
 
     #[test]
     fn logs_filter() {

--- a/src/api/eth_subscribe.rs
+++ b/src/api/eth_subscribe.rs
@@ -1,8 +1,5 @@
 //! `Eth` namespace, subscriptions
 
-use std::marker::PhantomData;
-use std::pin::Pin;
-
 use crate::api::Namespace;
 use crate::helpers::{self, CallFuture};
 use crate::types::{BlockHeader, Filter, Log, SyncState, H256};
@@ -11,8 +8,8 @@ use futures::{
     task::{Context, Poll},
     Future, FutureExt, Stream, StreamExt,
 };
-use serde;
-use serde_json;
+use std::marker::PhantomData;
+use std::pin::Pin;
 
 /// `Eth` namespace, subscriptions
 #[derive(Debug, Clone)]

--- a/src/api/personal.rs
+++ b/src/api/personal.rs
@@ -87,7 +87,7 @@ mod tests {
 
     use super::Personal;
 
-    const EXAMPLE_TX: &'static str = r#"{
+    const EXAMPLE_TX: &str = r#"{
     "raw": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",
     "tx": {
       "hash": "0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b",

--- a/src/api/traces.rs
+++ b/src/api/traces.rs
@@ -104,7 +104,7 @@ mod tests {
 
     use super::Traces;
 
-    const EXAMPLE_BLOCKTRACE: &'static str = r#"
+    const EXAMPLE_BLOCKTRACE: &str = r#"
     {
         "output": "0x010203",
         "stateDiff": null,
@@ -131,7 +131,7 @@ mod tests {
     }
     "#;
 
-    const EXAMPLE_BLOCKTRACES: &'static str = r#"
+    const EXAMPLE_BLOCKTRACES: &str = r#"
 	[{
         "output": "0x",
         "stateDiff": null,
@@ -159,7 +159,7 @@ mod tests {
     }]
 	"#;
 
-    const EXAMPLE_TRACE_ARR: &'static str = r#"
+    const EXAMPLE_TRACE_ARR: &str = r#"
     [
         {
             "action": {
@@ -185,7 +185,7 @@ mod tests {
     ]
     "#;
 
-    const EXAMPLE_TRACE: &'static str = r#"
+    const EXAMPLE_TRACE: &str = r#"
       {
           "action": {
               "callType": "call",

--- a/src/api/txpool.rs
+++ b/src/api/txpool.rs
@@ -48,7 +48,7 @@ mod tests {
 
     use super::Txpool;
 
-    const EXAMPLE_CONTENT_INFO: &'static str = r#"{
+    const EXAMPLE_CONTENT_INFO: &str = r#"{
         "pending": {
             "0x0216d5032f356960cd3749c31ab34eeff21b3395": {
               "806": {
@@ -128,7 +128,7 @@ mod tests {
           }
         }"#;
 
-    const EXAMPLE_INSPECT_INFO: &'static str = r#"{
+    const EXAMPLE_INSPECT_INFO: &str = r#"{
         "pending": {
           "0x26588a9301b0428d95e6fc3a5024fce8bec12d51": {
             "31813": "0x3375ee30428b2a71c428afa5e89e427905f95f7e: 0 wei + 500000 × 20000000000 gas"
@@ -178,7 +178,7 @@ mod tests {
         }
       }"#;
 
-    const EXAMPLE_STATUS: &'static str = r#"{
+    const EXAMPLE_STATUS: &str = r#"{
         "pending": "0xa",
         "queued": "0x7"
     }"#;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -9,8 +9,6 @@ use futures::{
     task::{Context, Poll},
     Future, FutureExt,
 };
-use serde;
-use serde_json;
 
 /// Value-decoder future.
 /// Takes any type which is deserializable from rpc::Value and a future which yields that

--- a/src/types/log.rs
+++ b/src/types/log.rs
@@ -1,5 +1,4 @@
 use crate::types::{BlockNumber, Bytes, Index, H160, H256, U256, U64};
-use ethabi;
 use serde::{Deserialize, Serialize, Serializer};
 
 /// A log produced by a transaction.
@@ -176,7 +175,6 @@ mod tests {
         log::{Bytes, FilterBuilder, Log},
         Address, H160, H256,
     };
-    use ethabi;
 
     #[test]
     fn is_removed_removed_true() {

--- a/src/types/sync_state.rs
+++ b/src/types/sync_state.rs
@@ -110,8 +110,6 @@ impl Serialize for SyncState {
 mod tests {
     use super::{SyncInfo, SyncState};
 
-    use serde_json;
-
     #[test]
     fn should_deserialize_rpc_sync_info() {
         let sync_state = r#"{

--- a/src/types/trace_filtering.rs
+++ b/src/types/trace_filtering.rs
@@ -277,7 +277,7 @@ pub enum RewardType {
 mod tests {
     use super::*;
 
-    const EXAMPLE_TRACE_CALL: &'static str = r#"{
+    const EXAMPLE_TRACE_CALL: &str = r#"{
         "action": {
             "callType": "call",
             "from": "0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb",
@@ -299,7 +299,7 @@ mod tests {
         "type": "call"
     }"#;
 
-    const EXAMPLE_TRACE_CREATE: &'static str = r#"{
+    const EXAMPLE_TRACE_CREATE: &str = r#"{
         "action": {
             "from": "0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb",
             "gas": "0x63ab9",
@@ -319,7 +319,7 @@ mod tests {
         "type": "create"
     }"#;
 
-    const EXAMPLE_TRACE_SUICIDE: &'static str = r#"{
+    const EXAMPLE_TRACE_SUICIDE: &str = r#"{
         "action": {
             "address": "0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb",
             "refundAddress": "0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359",
@@ -338,7 +338,7 @@ mod tests {
         "type": "suicide"
     }"#;
 
-    const EXAMPLE_TRACE_REWARD: &'static str = r#"{
+    const EXAMPLE_TRACE_REWARD: &str = r#"{
         "action": {
             "author": "0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb",
             "value": "0x0",

--- a/src/types/traces.rs
+++ b/src/types/traces.rs
@@ -161,17 +161,16 @@ pub struct StorageDiff {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json;
 
     // tx: https://etherscan.io/tx/0x4a91b11dbd2b11c308cfe7775eac2036f20c501691e3f8005d83b2dcce62d6b5
     // using the 'trace_replayTransaction' API function
     // with 'trace', 'vmTrace', 'stateDiff'
-    const EXAMPLE_TRACE: &'static str = include!("./example-trace-str.rs");
+    const EXAMPLE_TRACE: &str = include!("./example-trace-str.rs");
 
     // block: https://etherscan.io/block/46147
     // using the 'trace_replayBlockTransactions' API function
     // with 'trace', 'vmTrace', 'stateDiff'
-    const EXAMPLE_TRACES: &'static str = include!("./example-traces-str.rs");
+    const EXAMPLE_TRACES: &str = include!("./example-traces-str.rs");
 
     #[test]
     fn test_serialize_trace_type() {

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -122,7 +122,6 @@ pub struct RawTransactionDetails {
 mod tests {
     use super::RawTransaction;
     use super::Receipt;
-    use serde_json;
 
     #[test]
     fn test_deserialize_receipt() {

--- a/src/types/transaction_request.rs
+++ b/src/types/transaction_request.rs
@@ -73,7 +73,6 @@ pub enum TransactionCondition {
 #[cfg(test)]
 mod tests {
     use super::{Address, CallRequest, TransactionCondition, TransactionRequest};
-    use serde_json;
 
     #[test]
     fn should_serialize_call_request() {

--- a/src/types/txpool.rs
+++ b/src/types/txpool.rs
@@ -56,7 +56,6 @@ pub struct TxpoolStatus {
 #[cfg(test)]
 mod tests {
     use super::{TxpoolContentInfo, TxpoolInspectInfo, TxpoolStatus};
-    use serde_json;
 
     #[test]
     fn should_deserialize_txpool_content() {

--- a/src/types/uint.rs
+++ b/src/types/uint.rs
@@ -3,7 +3,6 @@ pub use ethereum_types::{BigEndianHash, Bloom as H2048, H128, H160, H256, H512, 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json;
 
     type Res = Result<U256, serde_json::Error>;
 


### PR DESCRIPTION
Fixes all warnings emitted by clippy because all of them were
reasonable.

When I was touching imports I removed some empty lines because rustfmt
already orders imports.