### PR TITLE
Remove more instances of Unpin

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -98,13 +98,12 @@ pub mod tests {
     use crate::error::{self, Error};
     use crate::rpc;
     use crate::{RequestId, Transport};
-    use futures::future;
+    use futures::future::{self, BoxFuture, FutureExt};
     use std::cell::RefCell;
     use std::collections::VecDeque;
-    use std::marker::Unpin;
     use std::rc::Rc;
 
-    type Result<T> = Box<dyn futures::Future<Output = error::Result<T>> + Send + Unpin>;
+    type Result<T> = BoxFuture<'static, error::Result<T>>;
 
     #[derive(Debug, Default, Clone)]
     pub struct TestTransport {
@@ -123,13 +122,14 @@ pub mod tests {
         }
 
         fn send(&self, id: RequestId, request: rpc::Call) -> Result<rpc::Value> {
-            Box::new(future::ready(match self.responses.borrow_mut().pop_front() {
+            future::ready(match self.responses.borrow_mut().pop_front() {
                 Some(response) => Ok(response),
                 None => {
                     println!("Unexpected request (id: {:?}): {:?}", id, request);
                     Err(Error::Unreachable)
                 }
-            }))
+            })
+            .boxed()
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,15 +138,14 @@ mod tests {
     use super::{error, rpc, RequestId, Transport};
 
     use crate::api::Web3;
-    use futures::Future;
-    use std::marker::Unpin;
+    use futures::future::BoxFuture;
     use std::sync::Arc;
 
     #[derive(Debug, Clone)]
     struct FakeTransport;
 
     impl Transport for FakeTransport {
-        type Out = Box<dyn Future<Output = error::Result<rpc::Value>> + Send + Unpin>;
+        type Out = BoxFuture<'static, error::Result<rpc::Value>>;
 
         fn prepare(&self, _method: &str, _params: Vec<rpc::Value>) -> (RequestId, rpc::Call) {
             unimplemented!()

--- a/src/transports/http.rs
+++ b/src/transports/http.rs
@@ -229,10 +229,13 @@ impl<T> Response<T> {
     }
 }
 
+// We can do this because `hyper::client::ResponseFuture: Unpin`.
+impl<T> Unpin for Response<T> {}
+
 impl<T, Out> Future for Response<T>
 where
-    T: Fn(Vec<u8>) -> error::Result<Out> + Unpin,
-    Out: fmt::Debug + Unpin,
+    T: Fn(Vec<u8>) -> error::Result<Out>,
+    Out: fmt::Debug,
 {
     type Output = error::Result<Out>;
 


### PR DESCRIPTION
Not required for `Transport` but I thought I'd clean up all of the remaining Unpin instances (except for `ws.rs`).