### PR TITLE
Add EIP-1193 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ before_script:
   - if [[ "${TRAVIS_RUST_VERSION}" == stable ]]; then
       rustup component add rustfmt && cargo install cargo-deny;
     fi
+  - rustup target add wasm32-unknown-unknown
 
 script:
   - if [[ "${TRAVIS_RUST_VERSION}" == "stable" ]]; then
@@ -42,6 +43,7 @@ script:
   - cargo build
   - cargo test
   - cargo check --no-default-features
+  - cargo check --target wasm32-unknown-unknown --no-default-features --features eip-1193
   - cargo check --no-default-features --features http
   - cargo check --no-default-features --features http-tls
   - cargo check --no-default-features --features ws-tokio

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,12 @@ soketto = { version = "0.4.1", optional = true }
 ## Shared (WS, HTTP)
 native-tls = { version = "0.2", optional = true }
 url = { version = "2.1", optional = true }
+## EIP-1193
+js-sys = { version = "0.3.45", optional = true }
+### This is a transitive dependency, only here so we can turn on its wasm_bindgen feature
+rand = { version = "0.7.3", optional = true }
+wasm-bindgen = { version = "0.2.68", optional = true, features = ["serde-serialize"] }
+wasm-bindgen-futures = { version = "0.4.18", optional = true }
 
 [dev-dependencies]
 # For examples
@@ -52,6 +58,7 @@ tokio = { version = "0.2", features = ["full"] }
 
 [features]
 default = ["http-tls", "signing", "ws-tls-tokio"]
+eip-1193 = ["js-sys", "wasm-bindgen", "wasm-bindgen-futures", "futures-timer/wasm-bindgen", "rand/wasm-bindgen"]
 http = ["hyper", "hyper-proxy", "url", "base64", "typed-headers"]
 http-tls = ["hyper-tls", "native-tls", "http"]
 signing = ["secp256k1"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ log = "0.4.6"
 parking_lot = "0.11.0"
 rlp = "0.4"
 rustc-hex = "2.1.0"
-secp256k1 = { version = "0.19", features = ["recovery"] }
+secp256k1 = { version = "0.19", features = ["recovery"], optional = true }
 serde = { version = "1.0.90", features = ["derive"] }
 serde_json = "1.0.39"
 tiny-keccak = { version = "2.0.1", features = ["keccak"] }
@@ -51,9 +51,10 @@ env_logger = "0.8"
 tokio = { version = "0.2", features = ["full"] }
 
 [features]
-default = ["http-tls", "ws-tls-tokio"]
+default = ["http-tls", "signing", "ws-tls-tokio"]
 http = ["hyper", "hyper-proxy", "url", "base64", "typed-headers"]
 http-tls = ["hyper-tls", "native-tls", "http"]
+signing = ["secp256k1"]
 ws-tokio = ["soketto", "url", "tokio", "tokio-util"]
 ws-async-std = ["soketto", "url", "async-std"]
 ws-tls-tokio = ["async-native-tls", "native-tls", "async-native-tls/runtime-tokio", "ws-tokio"]

--- a/src/api/accounts.rs
+++ b/src/api/accounts.rs
@@ -1,23 +1,15 @@
 //! Partial implementation of the `Accounts` namespace.
 
 use crate::api::Namespace;
-#[cfg(feature = "signing")]
-use crate::api::Web3;
-#[cfg(feature = "signing")]
-use crate::error;
 use crate::signing;
 #[cfg(feature = "signing")]
 use crate::signing::Signature;
 use crate::types::H256;
 #[cfg(feature = "signing")]
-use crate::types::{
-    Address, Bytes, Recovery, RecoveryMessage, SignedData, SignedTransaction, TransactionParameters, U256,
-};
+use crate::types::{Address, SignedTransaction, U256};
 use crate::Transport;
 #[cfg(feature = "signing")]
 use rlp::RlpStream;
-#[cfg(feature = "signing")]
-use std::convert::TryInto;
 
 /// `Accounts` namespace
 #[derive(Debug, Clone)]
@@ -39,54 +31,6 @@ impl<T: Transport> Namespace<T> for Accounts<T> {
 }
 
 impl<T: Transport> Accounts<T> {
-    /// Gets the parent `web3` namespace
-    #[cfg(feature = "signing")]
-    fn web3(&self) -> Web3<T> {
-        Web3::new(self.transport.clone())
-    }
-
-    /// Signs an Ethereum transaction with a given private key.
-    ///
-    /// Transaction signing can perform RPC requests in order to fill missing
-    /// parameters required for signing `nonce`, `gas_price` and `chain_id`. Note
-    /// that if all transaction parameters were provided, this future will resolve
-    /// immediately.
-    #[cfg(feature = "signing")]
-    pub async fn sign_transaction<K: signing::Key>(
-        &self,
-        tx: TransactionParameters,
-        key: K,
-    ) -> error::Result<SignedTransaction> {
-        macro_rules! maybe {
-            ($o: expr, $f: expr) => {
-                async {
-                    match $o {
-                        Some(value) => Ok(value),
-                        None => $f.await,
-                    }
-                }
-            };
-        }
-        let from = key.address();
-        let (nonce, gas_price, chain_id) = futures::future::try_join3(
-            maybe!(tx.nonce, self.web3().eth().transaction_count(from, None)),
-            maybe!(tx.gas_price, self.web3().eth().gas_price()),
-            maybe!(tx.chain_id.map(U256::from), self.web3().eth().chain_id()),
-        )
-        .await?;
-        let chain_id = chain_id.as_u64();
-        let tx = Transaction {
-            to: tx.to,
-            nonce,
-            gas: tx.gas,
-            gas_price,
-            value: tx.value,
-            data: tx.data.0,
-        };
-        let signed = tx.sign(key, chain_id);
-        Ok(signed)
-    }
-
     /// Hash a message according to EIP-191.
     ///
     /// The data is a UTF-8 encoded string and will enveloped as follows:
@@ -103,70 +47,127 @@ impl<T: Transport> Accounts<T> {
 
         signing::keccak256(&eth_message).into()
     }
+}
 
-    /// Sign arbitrary string data.
-    ///
-    /// The data is UTF-8 encoded and enveloped the same way as with
-    /// `hash_message`. The returned signed data's signature is in 'Electrum'
-    /// notation, that is the recovery value `v` is either `27` or `28` (as
-    /// opposed to the standard notation where `v` is either `0` or `1`). This
-    /// is important to consider when using this signature with other crates.
-    #[cfg(feature = "signing")]
-    pub fn sign<S>(&self, message: S, key: impl signing::Key) -> SignedData
-    where
-        S: AsRef<[u8]>,
-    {
-        let message = message.as_ref();
-        let message_hash = self.hash_message(message);
+#[cfg(feature = "signing")]
+mod accounts_signing {
+    use super::*;
+    use crate::api::Web3;
+    use crate::error;
+    use crate::types::{
+        Address, Bytes, Recovery, RecoveryMessage, SignedData, SignedTransaction, TransactionParameters, U256,
+    };
+    use std::convert::TryInto;
 
-        let signature = key
-            .sign(&message_hash.as_bytes(), None)
-            .expect("hash is non-zero 32-bytes; qed");
-        let v = signature
-            .v
-            .try_into()
-            .expect("signature recovery in electrum notation always fits in a u8");
-
-        let signature_bytes = Bytes({
-            let mut bytes = Vec::with_capacity(65);
-            bytes.extend_from_slice(signature.r.as_bytes());
-            bytes.extend_from_slice(signature.s.as_bytes());
-            bytes.push(v);
-            bytes
-        });
-
-        // We perform this allocation only after all previous fallible actions have completed successfully.
-        let message = message.to_owned();
-
-        SignedData {
-            message,
-            message_hash,
-            v,
-            r: signature.r,
-            s: signature.s,
-            signature: signature_bytes,
+    impl<T: Transport> Accounts<T> {
+        /// Gets the parent `web3` namespace
+        fn web3(&self) -> Web3<T> {
+            Web3::new(self.transport.clone())
         }
-    }
 
-    /// Recovers the Ethereum address which was used to sign the given data.
-    ///
-    /// Recovery signature data uses 'Electrum' notation, this means the `v`
-    /// value is expected to be either `27` or `28`.
-    #[cfg(feature = "signing")]
-    pub fn recover<R>(&self, recovery: R) -> error::Result<Address>
-    where
-        R: Into<Recovery>,
-    {
-        let recovery = recovery.into();
-        let message_hash = match recovery.message {
-            RecoveryMessage::Data(ref message) => self.hash_message(message),
-            RecoveryMessage::Hash(hash) => hash,
-        };
-        let (signature, recovery_id) = recovery
-            .as_signature()
-            .ok_or_else(|| error::Error::Recovery(signing::RecoveryError::InvalidSignature))?;
-        let address = signing::recover(message_hash.as_bytes(), &signature, recovery_id)?;
-        Ok(address)
+        /// Signs an Ethereum transaction with a given private key.
+        ///
+        /// Transaction signing can perform RPC requests in order to fill missing
+        /// parameters required for signing `nonce`, `gas_price` and `chain_id`. Note
+        /// that if all transaction parameters were provided, this future will resolve
+        /// immediately.
+        pub async fn sign_transaction<K: signing::Key>(
+            &self,
+            tx: TransactionParameters,
+            key: K,
+        ) -> error::Result<SignedTransaction> {
+            macro_rules! maybe {
+                ($o: expr, $f: expr) => {
+                    async {
+                        match $o {
+                            Some(value) => Ok(value),
+                            None => $f.await,
+                        }
+                    }
+                };
+            }
+            let from = key.address();
+            let (nonce, gas_price, chain_id) = futures::future::try_join3(
+                maybe!(tx.nonce, self.web3().eth().transaction_count(from, None)),
+                maybe!(tx.gas_price, self.web3().eth().gas_price()),
+                maybe!(tx.chain_id.map(U256::from), self.web3().eth().chain_id()),
+            )
+            .await?;
+            let chain_id = chain_id.as_u64();
+            let tx = Transaction {
+                to: tx.to,
+                nonce,
+                gas: tx.gas,
+                gas_price,
+                value: tx.value,
+                data: tx.data.0,
+            };
+            let signed = tx.sign(key, chain_id);
+            Ok(signed)
+        }
+
+        /// Sign arbitrary string data.
+        ///
+        /// The data is UTF-8 encoded and enveloped the same way as with
+        /// `hash_message`. The returned signed data's signature is in 'Electrum'
+        /// notation, that is the recovery value `v` is either `27` or `28` (as
+        /// opposed to the standard notation where `v` is either `0` or `1`). This
+        /// is important to consider when using this signature with other crates.
+        pub fn sign<S>(&self, message: S, key: impl signing::Key) -> SignedData
+        where
+            S: AsRef<[u8]>,
+        {
+            let message = message.as_ref();
+            let message_hash = self.hash_message(message);
+
+            let signature = key
+                .sign(&message_hash.as_bytes(), None)
+                .expect("hash is non-zero 32-bytes; qed");
+            let v = signature
+                .v
+                .try_into()
+                .expect("signature recovery in electrum notation always fits in a u8");
+
+            let signature_bytes = Bytes({
+                let mut bytes = Vec::with_capacity(65);
+                bytes.extend_from_slice(signature.r.as_bytes());
+                bytes.extend_from_slice(signature.s.as_bytes());
+                bytes.push(v);
+                bytes
+            });
+
+            // We perform this allocation only after all previous fallible actions have completed successfully.
+            let message = message.to_owned();
+
+            SignedData {
+                message,
+                message_hash,
+                v,
+                r: signature.r,
+                s: signature.s,
+                signature: signature_bytes,
+            }
+        }
+
+        /// Recovers the Ethereum address which was used to sign the given data.
+        ///
+        /// Recovery signature data uses 'Electrum' notation, this means the `v`
+        /// value is expected to be either `27` or `28`.
+        pub fn recover<R>(&self, recovery: R) -> error::Result<Address>
+        where
+            R: Into<Recovery>,
+        {
+            let recovery = recovery.into();
+            let message_hash = match recovery.message {
+                RecoveryMessage::Data(ref message) => self.hash_message(message),
+                RecoveryMessage::Hash(hash) => hash,
+            };
+            let (signature, recovery_id) = recovery
+                .as_signature()
+                .ok_or_else(|| error::Error::Recovery(signing::RecoveryError::InvalidSignature))?;
+            let address = signing::recover(message_hash.as_bytes(), &signature, recovery_id)?;
+            Ok(address)
+        }
     }
 }
 
@@ -220,7 +221,6 @@ impl Transaction {
     }
 
     /// Sign and return a raw signed transaction.
-    #[cfg(feature = "signing")]
     fn sign(self, sign: impl signing::Key, chain_id: u64) -> SignedTransaction {
         let mut rlp = RlpStream::new();
         self.rlp_append_unsigned(&mut rlp, chain_id);
@@ -252,7 +252,7 @@ mod tests {
     use super::*;
     use crate::signing::{SecretKey, SecretKeyRef};
     use crate::transports::test::TestTransport;
-    use crate::types::Bytes;
+    use crate::types::{Bytes, Recovery, TransactionParameters};
     use rustc_hex::FromHex;
     use serde_json::json;
 

--- a/src/api/accounts.rs
+++ b/src/api/accounts.rs
@@ -1,13 +1,22 @@
 //! Partial implementation of the `Accounts` namespace.
 
-use crate::api::{Namespace, Web3};
+use crate::api::Namespace;
+#[cfg(feature = "signing")]
+use crate::api::Web3;
+#[cfg(feature = "signing")]
 use crate::error;
-use crate::signing::{self, Signature};
+use crate::signing;
+#[cfg(feature = "signing")]
+use crate::signing::Signature;
+use crate::types::H256;
+#[cfg(feature = "signing")]
 use crate::types::{
-    Address, Bytes, Recovery, RecoveryMessage, SignedData, SignedTransaction, TransactionParameters, H256, U256,
+    Address, Bytes, Recovery, RecoveryMessage, SignedData, SignedTransaction, TransactionParameters, U256,
 };
 use crate::Transport;
+#[cfg(feature = "signing")]
 use rlp::RlpStream;
+#[cfg(feature = "signing")]
 use std::convert::TryInto;
 
 /// `Accounts` namespace
@@ -31,6 +40,7 @@ impl<T: Transport> Namespace<T> for Accounts<T> {
 
 impl<T: Transport> Accounts<T> {
     /// Gets the parent `web3` namespace
+    #[cfg(feature = "signing")]
     fn web3(&self) -> Web3<T> {
         Web3::new(self.transport.clone())
     }
@@ -41,6 +51,7 @@ impl<T: Transport> Accounts<T> {
     /// parameters required for signing `nonce`, `gas_price` and `chain_id`. Note
     /// that if all transaction parameters were provided, this future will resolve
     /// immediately.
+    #[cfg(feature = "signing")]
     pub async fn sign_transaction<K: signing::Key>(
         &self,
         tx: TransactionParameters,
@@ -100,6 +111,7 @@ impl<T: Transport> Accounts<T> {
     /// notation, that is the recovery value `v` is either `27` or `28` (as
     /// opposed to the standard notation where `v` is either `0` or `1`). This
     /// is important to consider when using this signature with other crates.
+    #[cfg(feature = "signing")]
     pub fn sign<S>(&self, message: S, key: impl signing::Key) -> SignedData
     where
         S: AsRef<[u8]>,
@@ -140,6 +152,7 @@ impl<T: Transport> Accounts<T> {
     ///
     /// Recovery signature data uses 'Electrum' notation, this means the `v`
     /// value is expected to be either `27` or `28`.
+    #[cfg(feature = "signing")]
     pub fn recover<R>(&self, recovery: R) -> error::Result<Address>
     where
         R: Into<Recovery>,
@@ -158,6 +171,7 @@ impl<T: Transport> Accounts<T> {
 }
 
 /// A transaction used for RLP encoding, hashing and signing.
+#[cfg(feature = "signing")]
 struct Transaction {
     to: Option<Address>,
     nonce: U256,
@@ -167,6 +181,7 @@ struct Transaction {
     data: Vec<u8>,
 }
 
+#[cfg(feature = "signing")]
 impl Transaction {
     /// RLP encode an unsigned transaction for the specified chain ID.
     fn rlp_append_unsigned(&self, rlp: &mut RlpStream, chain_id: u64) {
@@ -205,6 +220,7 @@ impl Transaction {
     }
 
     /// Sign and return a raw signed transaction.
+    #[cfg(feature = "signing")]
     fn sign(self, sign: impl signing::Key, chain_id: u64) -> SignedTransaction {
         let mut rlp = RlpStream::new();
         self.rlp_append_unsigned(&mut rlp, chain_id);

--- a/src/api/eth.rs
+++ b/src/api/eth.rs
@@ -171,6 +171,13 @@ impl<T: Transport> Eth<T> {
         CallFuture::new(self.transport.execute("eth_chainId", vec![]))
     }
 
+    /// Get available user accounts. This method is only available in the browser. With MetaMask,
+    /// this will cause the popup that prompts the user to allow or deny access to their accounts
+    /// to your app.
+    pub fn request_accounts(&self) -> CallFuture<Vec<Address>, T::Out> {
+        CallFuture::new(self.transport.execute("eth_requestAccounts", vec![]))
+    }
+
     /// Get storage entry
     pub fn storage(&self, address: Address, idx: U256, block: Option<BlockNumber>) -> CallFuture<H256, T::Out> {
         let address = helpers::serialize(&address);

--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -1,12 +1,17 @@
 //! Ethereum Contract Interface
 
-use crate::api::{Accounts, Eth, Namespace};
+#[cfg(feature = "signing")]
+use crate::api::Accounts;
+use crate::api::{Eth, Namespace};
 use crate::confirm;
 use crate::contract::tokens::{Detokenize, Tokenize};
+#[cfg(feature = "signing")]
 use crate::signing;
+#[cfg(feature = "signing")]
+use crate::types::TransactionParameters;
 use crate::types::{
-    Address, BlockId, Bytes, CallRequest, FilterBuilder, TransactionCondition, TransactionParameters,
-    TransactionReceipt, TransactionRequest, H256, U256,
+    Address, BlockId, Bytes, CallRequest, FilterBuilder, TransactionCondition, TransactionReceipt, TransactionRequest,
+    H256, U256,
 };
 use crate::Transport;
 use std::{collections::HashMap, hash::Hash, time};
@@ -142,6 +147,7 @@ impl<T: Transport> Contract<T> {
     }
 
     /// Execute a signed contract function and wait for confirmations
+    #[cfg(feature = "signing")]
     pub async fn signed_call_with_confirmations(
         &self,
         func: &str,

--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -1,14 +1,8 @@
 //! Ethereum Contract Interface
 
-#[cfg(feature = "signing")]
-use crate::api::Accounts;
 use crate::api::{Eth, Namespace};
 use crate::confirm;
 use crate::contract::tokens::{Detokenize, Tokenize};
-#[cfg(feature = "signing")]
-use crate::signing;
-#[cfg(feature = "signing")]
-use crate::types::TransactionParameters;
 use crate::types::{
     Address, BlockId, Bytes, CallRequest, FilterBuilder, TransactionCondition, TransactionReceipt, TransactionRequest,
     H256, U256,
@@ -146,49 +140,6 @@ impl<T: Transport> Contract<T> {
             .map_err(Error::from)
     }
 
-    /// Execute a signed contract function and wait for confirmations
-    #[cfg(feature = "signing")]
-    pub async fn signed_call_with_confirmations(
-        &self,
-        func: &str,
-        params: impl Tokenize,
-        options: Options,
-        confirmations: usize,
-        key: impl signing::Key,
-    ) -> crate::Result<TransactionReceipt> {
-        let poll_interval = time::Duration::from_secs(1);
-
-        let fn_data = self
-            .abi
-            .function(func)
-            .and_then(|function| function.encode_input(&params.into_tokens()))
-            // TODO [ToDr] SendTransactionWithConfirmation should support custom error type (so that we can return
-            // `contract::Error` instead of more generic `Error`.
-            .map_err(|err| crate::error::Error::Decoder(format!("{:?}", err)))?;
-        let accounts = Accounts::new(self.eth.transport().clone());
-        let mut tx = TransactionParameters {
-            nonce: options.nonce,
-            to: Some(self.address),
-            gas_price: options.gas_price,
-            data: Bytes(fn_data),
-            ..Default::default()
-        };
-        if let Some(gas) = options.gas {
-            tx.gas = gas;
-        }
-        if let Some(value) = options.value {
-            tx.value = value;
-        }
-        let signed = accounts.sign_transaction(tx, key).await?;
-        confirm::send_raw_transaction_with_confirmation(
-            self.eth.transport().clone(),
-            signed.raw_transaction,
-            poll_interval,
-            confirmations,
-        )
-        .await
-    }
-
     /// Execute a contract function and wait for confirmations
     pub async fn call_with_confirmations(
         &self,
@@ -322,6 +273,58 @@ impl<T: Transport> Contract<T> {
                 )?)
             })
             .collect::<Result<Vec<R>>>()
+    }
+}
+
+#[cfg(feature = "signing")]
+mod contract_signing {
+    use crate::api::Accounts;
+    use crate::signing;
+    use crate::types::TransactionParameters;
+
+    use super::*;
+    impl<T: Transport> Contract<T> {
+        /// Execute a signed contract function and wait for confirmations
+        pub async fn signed_call_with_confirmations(
+            &self,
+            func: &str,
+            params: impl Tokenize,
+            options: Options,
+            confirmations: usize,
+            key: impl signing::Key,
+        ) -> crate::Result<TransactionReceipt> {
+            let poll_interval = time::Duration::from_secs(1);
+
+            let fn_data = self
+                .abi
+                .function(func)
+                .and_then(|function| function.encode_input(&params.into_tokens()))
+                // TODO [ToDr] SendTransactionWithConfirmation should support custom error type (so that we can return
+                // `contract::Error` instead of more generic `Error`.
+                .map_err(|err| crate::error::Error::Decoder(format!("{:?}", err)))?;
+            let accounts = Accounts::new(self.eth.transport().clone());
+            let mut tx = TransactionParameters {
+                nonce: options.nonce,
+                to: Some(self.address),
+                gas_price: options.gas_price,
+                data: Bytes(fn_data),
+                ..Default::default()
+            };
+            if let Some(gas) = options.gas {
+                tx.gas = gas;
+            }
+            if let Some(value) = options.value {
+                tx.value = value;
+            }
+            let signed = accounts.sign_transaction(tx, key).await?;
+            confirm::send_raw_transaction_with_confirmation(
+                self.eth.transport().clone(),
+                signed.raw_transaction,
+                poll_interval,
+                confirmations,
+            )
+            .await
+        }
     }
 }
 

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -1,10 +1,16 @@
 //! Signing capabilities and utilities.
 
-use crate::types::{Address, H256};
+#[cfg(feature = "signing")]
+use crate::types::Address;
+use crate::types::H256;
+#[cfg(feature = "signing")]
 use secp256k1::recovery::{RecoverableSignature, RecoveryId};
+#[cfg(feature = "signing")]
 use secp256k1::{Message, PublicKey, Secp256k1};
+#[cfg(feature = "signing")]
 use std::ops::Deref;
 
+#[cfg(feature = "signing")]
 pub(crate) use secp256k1::SecretKey;
 
 /// Error during signing.
@@ -41,6 +47,7 @@ impl std::error::Error for RecoveryError {}
 ///
 /// If it's enough to pass a reference to `SecretKey` (lifetimes) than you can use `SecretKeyRef`
 /// wrapper.
+#[cfg(feature = "signing")]
 pub trait Key {
     /// Sign given message and include chain-id replay protection.
     ///
@@ -57,10 +64,12 @@ pub trait Key {
 ///
 /// A wrapper around `secp256k1::SecretKey` reference, which enables it to be used in methods expecting
 /// `Key` capabilities.
+#[cfg(feature = "signing")]
 pub struct SecretKeyRef<'a> {
     key: &'a SecretKey,
 }
 
+#[cfg(feature = "signing")]
 impl<'a> SecretKeyRef<'a> {
     /// A simple wrapper around a reference to `SecretKey` which allows it to be usable for signing.
     pub fn new(key: &'a SecretKey) -> Self {
@@ -68,12 +77,14 @@ impl<'a> SecretKeyRef<'a> {
     }
 }
 
+#[cfg(feature = "signing")]
 impl<'a> From<&'a SecretKey> for SecretKeyRef<'a> {
     fn from(key: &'a SecretKey) -> Self {
         Self::new(key)
     }
 }
 
+#[cfg(feature = "signing")]
 impl<'a> Deref for SecretKeyRef<'a> {
     type Target = SecretKey;
 
@@ -82,6 +93,7 @@ impl<'a> Deref for SecretKeyRef<'a> {
     }
 }
 
+#[cfg(feature = "signing")]
 impl<T: Deref<Target = SecretKey>> Key for T {
     fn sign(&self, message: &[u8], chain_id: Option<u64>) -> Result<Signature, SigningError> {
         let message = Message::from_slice(&message).map_err(|_| SigningError::InvalidMessage)?;
@@ -121,6 +133,7 @@ pub struct Signature {
 /// Recover a sender, given message and the signature.
 ///
 /// Signature and `recovery_id` can be obtained from `types::Recovery` type.
+#[cfg(feature = "signing")]
 pub fn recover(message: &[u8], signature: &[u8], recovery_id: i32) -> Result<Address, RecoveryError> {
     let message = Message::from_slice(message).map_err(|_| RecoveryError::InvalidMessage)?;
     let recovery_id = RecoveryId::from_i32(recovery_id).map_err(|_| RecoveryError::InvalidSignature)?;
@@ -140,6 +153,7 @@ pub fn recover(message: &[u8], signature: &[u8], recovery_id: i32) -> Result<Add
 /// crate is 65 bytes long, that is because it is prefixed by `0x04` to
 /// indicate an uncompressed public key; this first byte is ignored when
 /// computing the hash.
+#[cfg(feature = "signing")]
 pub(crate) fn public_key_address(public_key: &PublicKey) -> Address {
     let public_key = public_key.serialize_uncompressed();
 
@@ -150,6 +164,7 @@ pub(crate) fn public_key_address(public_key: &PublicKey) -> Address {
 }
 
 /// Gets the public address of a private key.
+#[cfg(feature = "signing")]
 pub(crate) fn secret_key_address(key: &SecretKey) -> Address {
     let secp = Secp256k1::signing_only();
     let public_key = PublicKey::from_secret_key(&secp, key);

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -1,17 +1,6 @@
 //! Signing capabilities and utilities.
 
-#[cfg(feature = "signing")]
-use crate::types::Address;
 use crate::types::H256;
-#[cfg(feature = "signing")]
-use secp256k1::recovery::{RecoverableSignature, RecoveryId};
-#[cfg(feature = "signing")]
-use secp256k1::{Message, PublicKey, Secp256k1};
-#[cfg(feature = "signing")]
-use std::ops::Deref;
-
-#[cfg(feature = "signing")]
-pub(crate) use secp256k1::SecretKey;
 
 /// Error during signing.
 #[derive(Debug, derive_more::Display, PartialEq, Clone)]
@@ -34,89 +23,136 @@ pub enum RecoveryError {
 }
 impl std::error::Error for RecoveryError {}
 
-/// A trait representing ethereum-compatible key with signing capabilities.
-///
-/// The purpose of this trait is to prevent leaking `secp256k1::SecretKey` struct
-/// in stack or memory.
-/// To use secret keys securely, they should be wrapped in a struct that prevents
-/// leaving copies in memory (both when it's moved or dropped). Please take a look
-/// at:
-/// - https://github.com/graphprotocol/solidity-bindgen/blob/master/solidity-bindgen/src/secrets.rs
-/// - or https://crates.io/crates/zeroize
-/// if you care enough about your secrets to be used securely.
-///
-/// If it's enough to pass a reference to `SecretKey` (lifetimes) than you can use `SecretKeyRef`
-/// wrapper.
 #[cfg(feature = "signing")]
-pub trait Key {
-    /// Sign given message and include chain-id replay protection.
+pub use feature_gated::*;
+
+#[cfg(feature = "signing")]
+mod feature_gated {
+    use super::*;
+
+    use secp256k1::recovery::{RecoverableSignature, RecoveryId};
+    pub(crate) use secp256k1::SecretKey;
+    use secp256k1::{Message, PublicKey, Secp256k1};
+    use std::ops::Deref;
+
+    use crate::types::Address;
+
+    /// A trait representing ethereum-compatible key with signing capabilities.
     ///
-    /// When a chain ID is provided, the `Signature`'s V-value will have chain relay
-    /// protection added (as per EIP-155). Otherwise, the V-value will be in
-    /// 'Electrum' notation.
-    fn sign(&self, message: &[u8], chain_id: Option<u64>) -> Result<Signature, SigningError>;
+    /// The purpose of this trait is to prevent leaking `secp256k1::SecretKey` struct
+    /// in stack or memory.
+    /// To use secret keys securely, they should be wrapped in a struct that prevents
+    /// leaving copies in memory (both when it's moved or dropped). Please take a look
+    /// at:
+    /// - https://github.com/graphprotocol/solidity-bindgen/blob/master/solidity-bindgen/src/secrets.rs
+    /// - or https://crates.io/crates/zeroize
+    /// if you care enough about your secrets to be used securely.
+    ///
+    /// If it's enough to pass a reference to `SecretKey` (lifetimes) than you can use `SecretKeyRef`
+    /// wrapper.
+    pub trait Key {
+        /// Sign given message and include chain-id replay protection.
+        ///
+        /// When a chain ID is provided, the `Signature`'s V-value will have chain relay
+        /// protection added (as per EIP-155). Otherwise, the V-value will be in
+        /// 'Electrum' notation.
+        fn sign(&self, message: &[u8], chain_id: Option<u64>) -> Result<Signature, SigningError>;
 
-    /// Get public address that this key represents.
-    fn address(&self) -> Address;
-}
-
-/// A `SecretKey` reference wrapper.
-///
-/// A wrapper around `secp256k1::SecretKey` reference, which enables it to be used in methods expecting
-/// `Key` capabilities.
-#[cfg(feature = "signing")]
-pub struct SecretKeyRef<'a> {
-    key: &'a SecretKey,
-}
-
-#[cfg(feature = "signing")]
-impl<'a> SecretKeyRef<'a> {
-    /// A simple wrapper around a reference to `SecretKey` which allows it to be usable for signing.
-    pub fn new(key: &'a SecretKey) -> Self {
-        Self { key }
-    }
-}
-
-#[cfg(feature = "signing")]
-impl<'a> From<&'a SecretKey> for SecretKeyRef<'a> {
-    fn from(key: &'a SecretKey) -> Self {
-        Self::new(key)
-    }
-}
-
-#[cfg(feature = "signing")]
-impl<'a> Deref for SecretKeyRef<'a> {
-    type Target = SecretKey;
-
-    fn deref(&self) -> &Self::Target {
-        &self.key
-    }
-}
-
-#[cfg(feature = "signing")]
-impl<T: Deref<Target = SecretKey>> Key for T {
-    fn sign(&self, message: &[u8], chain_id: Option<u64>) -> Result<Signature, SigningError> {
-        let message = Message::from_slice(&message).map_err(|_| SigningError::InvalidMessage)?;
-        let (recovery_id, signature) = Secp256k1::signing_only()
-            .sign_recoverable(&message, self)
-            .serialize_compact();
-
-        let standard_v = recovery_id.to_i32() as u64;
-        let v = if let Some(chain_id) = chain_id {
-            // When signing with a chain ID, add chain replay protection.
-            standard_v + 35 + chain_id * 2
-        } else {
-            // Otherwise, convert to 'Electrum' notation.
-            standard_v + 27
-        };
-        let r = H256::from_slice(&signature[..32]);
-        let s = H256::from_slice(&signature[32..]);
-
-        Ok(Signature { v, r, s })
+        /// Get public address that this key represents.
+        fn address(&self) -> Address;
     }
 
-    fn address(&self) -> Address {
-        secret_key_address(self)
+    /// A `SecretKey` reference wrapper.
+    ///
+    /// A wrapper around `secp256k1::SecretKey` reference, which enables it to be used in methods expecting
+    /// `Key` capabilities.
+    pub struct SecretKeyRef<'a> {
+        pub(super) key: &'a SecretKey,
+    }
+
+    impl<'a> SecretKeyRef<'a> {
+        /// A simple wrapper around a reference to `SecretKey` which allows it to be usable for signing.
+        pub fn new(key: &'a SecretKey) -> Self {
+            Self { key }
+        }
+    }
+
+    impl<'a> From<&'a SecretKey> for SecretKeyRef<'a> {
+        fn from(key: &'a SecretKey) -> Self {
+            Self::new(key)
+        }
+    }
+
+    impl<'a> Deref for SecretKeyRef<'a> {
+        type Target = SecretKey;
+
+        fn deref(&self) -> &Self::Target {
+            &self.key
+        }
+    }
+
+    impl<T: Deref<Target = SecretKey>> Key for T {
+        fn sign(&self, message: &[u8], chain_id: Option<u64>) -> Result<Signature, SigningError> {
+            let message = Message::from_slice(&message).map_err(|_| SigningError::InvalidMessage)?;
+            let (recovery_id, signature) = Secp256k1::signing_only()
+                .sign_recoverable(&message, self)
+                .serialize_compact();
+
+            let standard_v = recovery_id.to_i32() as u64;
+            let v = if let Some(chain_id) = chain_id {
+                // When signing with a chain ID, add chain replay protection.
+                standard_v + 35 + chain_id * 2
+            } else {
+                // Otherwise, convert to 'Electrum' notation.
+                standard_v + 27
+            };
+            let r = H256::from_slice(&signature[..32]);
+            let s = H256::from_slice(&signature[32..]);
+
+            Ok(Signature { v, r, s })
+        }
+
+        fn address(&self) -> Address {
+            secret_key_address(self)
+        }
+    }
+
+    /// Recover a sender, given message and the signature.
+    ///
+    /// Signature and `recovery_id` can be obtained from `types::Recovery` type.
+    pub fn recover(message: &[u8], signature: &[u8], recovery_id: i32) -> Result<Address, RecoveryError> {
+        let message = Message::from_slice(message).map_err(|_| RecoveryError::InvalidMessage)?;
+        let recovery_id = RecoveryId::from_i32(recovery_id).map_err(|_| RecoveryError::InvalidSignature)?;
+        let signature =
+            RecoverableSignature::from_compact(&signature, recovery_id).map_err(|_| RecoveryError::InvalidSignature)?;
+        let public_key = Secp256k1::verification_only()
+            .recover(&message, &signature)
+            .map_err(|_| RecoveryError::InvalidSignature)?;
+
+        Ok(public_key_address(&public_key))
+    }
+
+    /// Gets the address of a public key.
+    ///
+    /// The public address is defined as the low 20 bytes of the keccak hash of
+    /// the public key. Note that the public key returned from the `secp256k1`
+    /// crate is 65 bytes long, that is because it is prefixed by `0x04` to
+    /// indicate an uncompressed public key; this first byte is ignored when
+    /// computing the hash.
+    pub(crate) fn public_key_address(public_key: &PublicKey) -> Address {
+        let public_key = public_key.serialize_uncompressed();
+
+        debug_assert_eq!(public_key[0], 0x04);
+        let hash = keccak256(&public_key[1..]);
+
+        Address::from_slice(&hash[12..])
+    }
+
+    /// Gets the public address of a private key.
+    pub(crate) fn secret_key_address(key: &SecretKey) -> Address {
+        let secp = Secp256k1::signing_only();
+        let public_key = PublicKey::from_secret_key(&secp, key);
+        public_key_address(&public_key)
     }
 }
 
@@ -128,47 +164,6 @@ pub struct Signature {
     pub r: H256,
     /// S component of the signature.
     pub s: H256,
-}
-
-/// Recover a sender, given message and the signature.
-///
-/// Signature and `recovery_id` can be obtained from `types::Recovery` type.
-#[cfg(feature = "signing")]
-pub fn recover(message: &[u8], signature: &[u8], recovery_id: i32) -> Result<Address, RecoveryError> {
-    let message = Message::from_slice(message).map_err(|_| RecoveryError::InvalidMessage)?;
-    let recovery_id = RecoveryId::from_i32(recovery_id).map_err(|_| RecoveryError::InvalidSignature)?;
-    let signature =
-        RecoverableSignature::from_compact(&signature, recovery_id).map_err(|_| RecoveryError::InvalidSignature)?;
-    let public_key = Secp256k1::verification_only()
-        .recover(&message, &signature)
-        .map_err(|_| RecoveryError::InvalidSignature)?;
-
-    Ok(public_key_address(&public_key))
-}
-
-/// Gets the address of a public key.
-///
-/// The public address is defined as the low 20 bytes of the keccak hash of
-/// the public key. Note that the public key returned from the `secp256k1`
-/// crate is 65 bytes long, that is because it is prefixed by `0x04` to
-/// indicate an uncompressed public key; this first byte is ignored when
-/// computing the hash.
-#[cfg(feature = "signing")]
-pub(crate) fn public_key_address(public_key: &PublicKey) -> Address {
-    let public_key = public_key.serialize_uncompressed();
-
-    debug_assert_eq!(public_key[0], 0x04);
-    let hash = keccak256(&public_key[1..]);
-
-    Address::from_slice(&hash[12..])
-}
-
-/// Gets the public address of a private key.
-#[cfg(feature = "signing")]
-pub(crate) fn secret_key_address(key: &SecretKey) -> Address {
-    let secp = Secp256k1::signing_only();
-    let public_key = PublicKey::from_secret_key(&secp, key);
-    public_key_address(&public_key)
 }
 
 /// Compute the Keccak-256 hash of input bytes.

--- a/src/transports/eip_1193.rs
+++ b/src/transports/eip_1193.rs
@@ -105,7 +105,7 @@ impl Transport for Eip1193 {
                     .await
                 })
             }
-            _other => Box::pin(future::err(Error::Internal)),
+            _ => panic!("Can't send JSON-RPC requests other than method calls with EIP-1193 transport!"),
         }
     }
 }
@@ -123,7 +123,7 @@ impl DuplexTransport for Eip1193 {
     fn unsubscribe(&self, id: SubscriptionId) -> error::Result<()> {
         match (*self.subscriptions.borrow_mut()).remove(&id) {
             Some(_sender) => Ok(()),
-            None => Err(Error::Internal),
+            None => panic!("Tried to unsubscribe from non-existent subscription. Did we already unsubscribe?"),
         }
     }
 }

--- a/src/transports/eip_1193.rs
+++ b/src/transports/eip_1193.rs
@@ -1,0 +1,189 @@
+//! EIP-1193 transport
+//!
+//! This transport lets you use the library inside a browser to interact with
+//! EIP-1193 providers like MetaMask. It's intended for use with Rust's
+//! WebAssembly target.
+
+#![cfg(feature = "eip-1193")]
+
+use crate::api::SubscriptionId;
+use crate::{error, DuplexTransport, Error, RequestId, Transport};
+use futures::channel::mpsc;
+use futures::future;
+use futures::future::LocalBoxFuture;
+use jsonrpc_core::types::request::{Call, MethodCall};
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::rc::Rc;
+use wasm_bindgen::prelude::*;
+
+/// EIP-1193 transport
+#[derive(Clone, Debug)]
+pub struct Eip1193 {
+    provider: Provider,
+    subscriptions: Rc<RefCell<BTreeMap<SubscriptionId, mpsc::UnboundedSender<serde_json::Value>>>>,
+}
+
+impl Eip1193 {
+    /// Build an EIP-1193 transport.
+    pub fn new(provider: Provider) -> Self {
+        let subscriptions: Rc<RefCell<BTreeMap<SubscriptionId, mpsc::UnboundedSender<serde_json::Value>>>> =
+            Rc::new(RefCell::new(BTreeMap::new()));
+        let subscriptions_for_closure = subscriptions.clone();
+        let msg_handler = Closure::wrap(Box::new(move |evt_js: JsValue| {
+            let evt: serde_json::Value = evt_js.into_serde().expect("couldn't translate notification via JSON");
+            log::trace!("Message from provider: {}", evt);
+            match evt.get("type").and_then(serde_json::Value::as_str) {
+                Some("eth_subscription") => {
+                    let data = evt
+                        .get("data")
+                        .and_then(serde_json::Value::as_object)
+                        .expect("couldn't get data field");
+                    let subscription = data
+                        .get("subscription")
+                        .and_then(serde_json::Value::as_str)
+                        .expect("couldn't get subscription field");
+                    let result = data.get("result").expect("couldn't get result field").clone();
+                    let subscriptions_map = subscriptions_for_closure.borrow();
+                    match subscriptions_map.get(&SubscriptionId::from(String::from(subscription))) {
+                        Some(sink) => {
+                            if let Err(err) = sink.unbounded_send(result) {
+                                log::error!("Error sending notification: {}", err)
+                            }
+                        }
+                        None => log::warn!("Got message for non-existent subscription {}", subscription),
+                    }
+                }
+                Some(other) => log::warn!("Got unknown notification type: {}", other),
+                None => log::error!("Got notification with no \"type\" field: {:?}", evt),
+            }
+        }) as Box<dyn FnMut(JsValue)>);
+        provider.on("message", &msg_handler);
+        msg_handler.into_js_value();
+        Eip1193 {
+            provider,
+            subscriptions,
+        }
+    }
+}
+
+impl Transport for Eip1193 {
+    type Out = LocalBoxFuture<'static, error::Result<serde_json::value::Value>>;
+
+    fn prepare(&self, method: &str, params: Vec<serde_json::Value>) -> (RequestId, Call) {
+        // EIP-1193 uses the JSON-RPC function API, but it isn't actually JSON-RPC, so some of
+        // these fields are ignored.
+        (
+            0,
+            Call::from(MethodCall {
+                jsonrpc: None,
+                method: String::from(method),
+                params: jsonrpc_core::types::Params::Array(params),
+                id: jsonrpc_core::types::Id::Null,
+            }),
+        )
+    }
+
+    fn send(&self, _id: RequestId, request: Call) -> Self::Out {
+        match request {
+            Call::MethodCall(method_call) => match method_call.params {
+                jsonrpc_core::types::Params::Array(ref params) => {
+                    let js_params = js_sys::Array::from(
+                        &JsValue::from_serde(params).expect("couldn't send method params via JSON"),
+                    );
+                    let copy = self.provider.clone();
+                    Box::pin(async move {
+                        copy.request_wrapped(RequestArguments {
+                            method: method_call.method,
+                            params: js_params,
+                        })
+                        .await
+                    })
+                }
+                _other => Box::pin(future::err(Error::Internal)),
+            },
+            _other => Box::pin(future::err(Error::Internal)),
+        }
+    }
+}
+
+impl DuplexTransport for Eip1193 {
+    type NotificationStream = mpsc::UnboundedReceiver<serde_json::Value>;
+
+    fn subscribe(&self, id: SubscriptionId) -> error::Result<Self::NotificationStream> {
+        let (sender, receiver) = mpsc::unbounded();
+        let mut subscriptions_ref = self.subscriptions.borrow_mut();
+        subscriptions_ref.insert(id, sender);
+        Ok(receiver)
+    }
+
+    fn unsubscribe(&self, id: SubscriptionId) -> error::Result<()> {
+        match (*self.subscriptions.borrow_mut()).remove(&id) {
+            Some(_sender) => Ok(()),
+            None => Err(Error::Internal),
+        }
+    }
+}
+
+#[wasm_bindgen]
+// Rustfmt removes the 'async' keyword from async functions in extern blocks. It's fixed
+// in rustfmt 2.
+#[rustfmt::skip]
+extern "C" {
+    #[wasm_bindgen]
+    #[derive(Clone, Debug)]
+    /// An EIP-1193 provider object. Available by convention at `window.ethereum`
+    pub type Provider;
+
+    #[wasm_bindgen(catch, method)]
+    async fn request(_: &Provider, args: RequestArguments) -> Result<JsValue, JsValue>;
+
+    #[wasm_bindgen(method)]
+    fn on(_: &Provider, eventName: &str, listener: &Closure<dyn FnMut(JsValue)>);
+}
+
+impl Provider {
+    /// Get the provider at `window.ethereum`.
+    pub fn get_default() -> Result<Self, JsValue> {
+        get_provider_js()
+    }
+
+    async fn request_wrapped(&self, args: RequestArguments) -> error::Result<serde_json::value::Value> {
+        let js_result = self.request(args).await;
+        match js_result {
+            Ok(res) => Ok(res.into_serde().expect("couldn't translate request via JSON")),
+            Err(err) => {
+                match err.into_serde() {
+                    Ok(json_rpc_err) => Err(Error::Rpc(json_rpc_err)),
+                    // THE EIP says an error response MUST match the JSON RPC error structure.
+                    Err(_) => Err(Error::InvalidResponse(format!("{:?}", err))),
+                }
+            }
+        }
+    }
+}
+
+#[wasm_bindgen(inline_js = "export function get_provider_js() {return window.ethereum}")]
+extern "C" {
+    #[wasm_bindgen(catch)]
+    fn get_provider_js() -> Result<Provider, JsValue>;
+}
+
+#[wasm_bindgen]
+struct RequestArguments {
+    method: String,
+    params: js_sys::Array,
+}
+
+#[wasm_bindgen]
+impl RequestArguments {
+    #[wasm_bindgen(getter)]
+    pub fn method(&self) -> String {
+        self.method.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn params(&self) -> js_sys::Array {
+        self.params.clone()
+    }
+}

--- a/src/transports/eip_1193.rs
+++ b/src/transports/eip_1193.rs
@@ -129,7 +129,6 @@ impl DuplexTransport for Eip1193 {
 // in rustfmt 2.
 #[rustfmt::skip]
 extern "C" {
-    #[wasm_bindgen]
     #[derive(Clone, Debug)]
     /// An EIP-1193 provider object. Available by convention at `window.ethereum`
     pub type Provider;

--- a/src/transports/eip_1193.rs
+++ b/src/transports/eip_1193.rs
@@ -146,7 +146,7 @@ extern "C" {
 
 impl Provider {
     /// Get the provider at `window.ethereum`.
-    pub fn get_default() -> Result<Self, JsValue> {
+    pub fn default() -> Result<Self, JsValue> {
         get_provider_js()
     }
 

--- a/src/transports/eip_1193.rs
+++ b/src/transports/eip_1193.rs
@@ -4,8 +4,6 @@
 //! EIP-1193 providers like MetaMask. It's intended for use with Rust's
 //! WebAssembly target.
 
-#![cfg(feature = "eip-1193")]
-
 use crate::api::SubscriptionId;
 use crate::{error, DuplexTransport, Error, RequestId, Transport};
 use futures::channel::mpsc;

--- a/src/transports/mod.rs
+++ b/src/transports/mod.rs
@@ -31,3 +31,6 @@ impl From<native_tls::Error> for crate::Error {
         crate::Error::Transport(format!("{:?}", err))
     }
 }
+
+#[cfg(feature = "eip-1193")]
+pub mod eip_1193;


### PR DESCRIPTION
I added support for EIP-1193 and got the library working in the browser. This will be easier to review commit-by-commit.

For an example of the new functionality in use, you can check out the `eip-1193-with-example` branch from my fork. To run: `wasm-pack build -- --no-default-features --features eip-1193 && cd www && npm install && npm run start`. Then open http://127.0.0.1:8080 in a browser with MetaMask installed. Reject the transaction when prompted unless you enjoy burning 1 ETH for no reason.

This is my first substantial Rust code, feedback is very appreciated.