### PR TITLE
Merge imports

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,4 +32,4 @@ jobs:
         uses:           actions-rs/cargo@master
         with:
           command:      fmt
-          args:         --all -- --check
+          args:         --all -- --check --config merge_imports=true

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -1,6 +1,8 @@
 use parking_lot::Mutex;
-use std::sync::{atomic, Arc};
-use std::{thread, time};
+use std::{
+    sync::{atomic, Arc},
+    thread, time,
+};
 
 #[tokio::main]
 async fn main() -> web3::Result {

--- a/examples/contract.rs
+++ b/examples/contract.rs
@@ -1,6 +1,8 @@
 use hex_literal::hex;
-use web3::contract::{Contract, Options};
-use web3::types::U256;
+use web3::{
+    contract::{Contract, Options},
+    types::U256,
+};
 
 #[tokio::main]
 async fn main() -> web3::contract::Result<()> {

--- a/examples/contract_log_filter.rs
+++ b/examples/contract_log_filter.rs
@@ -1,8 +1,10 @@
 use hex_literal::hex;
 use std::time;
-use web3::contract::{Contract, Options};
-use web3::futures::StreamExt;
-use web3::types::FilterBuilder;
+use web3::{
+    contract::{Contract, Options},
+    futures::StreamExt,
+    types::FilterBuilder,
+};
 
 #[tokio::main]
 async fn main() -> web3::contract::Result<()> {

--- a/examples/contract_log_pubsub.rs
+++ b/examples/contract_log_pubsub.rs
@@ -1,8 +1,10 @@
 use hex_literal::hex;
 use std::time;
-use web3::contract::{Contract, Options};
-use web3::futures::{future, StreamExt};
-use web3::types::FilterBuilder;
+use web3::{
+    contract::{Contract, Options},
+    futures::{future, StreamExt},
+    types::FilterBuilder,
+};
 
 #[tokio::main]
 async fn main() -> web3::contract::Result<()> {

--- a/examples/contract_storage.rs
+++ b/examples/contract_storage.rs
@@ -1,8 +1,10 @@
 //based on examples/contract.rs
 
 use std::time;
-use web3::contract::{Contract, Options};
-use web3::types::U256;
+use web3::{
+    contract::{Contract, Options},
+    types::U256,
+};
 
 #[tokio::main]
 async fn main() -> web3::contract::Result<()> {

--- a/src/api/accounts.rs
+++ b/src/api/accounts.rs
@@ -1,9 +1,6 @@
 //! Partial implementation of the `Accounts` namespace.
 
-use crate::api::Namespace;
-use crate::signing;
-use crate::types::H256;
-use crate::Transport;
+use crate::{api::Namespace, signing, types::H256, Transport};
 
 /// `Accounts` namespace
 #[derive(Debug, Clone)]
@@ -46,11 +43,13 @@ impl<T: Transport> Accounts<T> {
 #[cfg(feature = "signing")]
 mod accounts_signing {
     use super::*;
-    use crate::api::Web3;
-    use crate::error;
-    use crate::signing::Signature;
-    use crate::types::{
-        Address, Bytes, Recovery, RecoveryMessage, SignedData, SignedTransaction, TransactionParameters, U256,
+    use crate::{
+        api::Web3,
+        error,
+        signing::Signature,
+        types::{
+            Address, Bytes, Recovery, RecoveryMessage, SignedData, SignedTransaction, TransactionParameters, U256,
+        },
     };
     use rlp::RlpStream;
     use std::convert::TryInto;
@@ -243,13 +242,14 @@ mod accounts_signing {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::signing::{SecretKey, SecretKeyRef};
-    use crate::transports::test::TestTransport;
-    use crate::types::{Address, Recovery, SignedTransaction, TransactionParameters, U256};
+    use crate::{
+        signing::{SecretKey, SecretKeyRef},
+        transports::test::TestTransport,
+        types::{Address, Recovery, SignedTransaction, TransactionParameters, U256},
+    };
+    use accounts_signing::*;
     use hex_literal::hex;
     use serde_json::json;
-
-    use accounts_signing::*;
 
     #[test]
     fn accounts_sign_transaction() {

--- a/src/api/eth.rs
+++ b/src/api/eth.rs
@@ -1,12 +1,14 @@
 //! `Eth` namespace
 
-use crate::api::Namespace;
-use crate::helpers::{self, CallFuture};
-use crate::types::{
-    Address, Block, BlockHeader, BlockId, BlockNumber, Bytes, CallRequest, Filter, Index, Log, SyncState, Transaction,
-    TransactionId, TransactionReceipt, TransactionRequest, Work, H256, H520, H64, U256, U64,
+use crate::{
+    api::Namespace,
+    helpers::{self, CallFuture},
+    types::{
+        Address, Block, BlockHeader, BlockId, BlockNumber, Bytes, CallRequest, Filter, Index, Log, SyncState,
+        Transaction, TransactionId, TransactionReceipt, TransactionRequest, Work, H256, H520, H64, U256, U64,
+    },
+    Transport,
 };
-use crate::Transport;
 
 /// `Eth` namespace
 #[derive(Debug, Clone)]
@@ -349,17 +351,17 @@ impl<T: Transport> Eth<T> {
 
 #[cfg(test)]
 mod tests {
+    use super::Eth;
+    use crate::{
+        api::Namespace,
+        rpc::Value,
+        types::{
+            Address, Block, BlockHeader, BlockId, BlockNumber, CallRequest, FilterBuilder, Log, SyncInfo, SyncState,
+            Transaction, TransactionId, TransactionReceipt, TransactionRequest, Work, H256, H520, H64,
+        },
+    };
     use hex_literal::hex;
     use serde_json::json;
-
-    use crate::api::Namespace;
-    use crate::rpc::Value;
-    use crate::types::{
-        Address, Block, BlockHeader, BlockId, BlockNumber, CallRequest, FilterBuilder, Log, SyncInfo, SyncState,
-        Transaction, TransactionId, TransactionReceipt, TransactionRequest, Work, H256, H520, H64,
-    };
-
-    use super::Eth;
 
     // taken from RPC docs.
     const EXAMPLE_BLOCK: &str = r#"{

--- a/src/api/eth_filter.rs
+++ b/src/api/eth_filter.rs
@@ -1,16 +1,15 @@
 //! `Eth` namespace, filters.
 
+use crate::{
+    api::Namespace,
+    error, helpers, rpc,
+    types::{Filter, Log, H256},
+    Transport,
+};
 use futures::{stream, Stream, TryStreamExt};
 use futures_timer::Delay;
 use serde::de::DeserializeOwned;
-use std::marker::PhantomData;
-use std::time::Duration;
-use std::{fmt, vec};
-
-use crate::api::Namespace;
-use crate::helpers;
-use crate::types::{Filter, Log, H256};
-use crate::{error, rpc, Transport};
+use std::{fmt, marker::PhantomData, time::Duration, vec};
 
 fn filter_stream<T: Transport, I: DeserializeOwned>(
     base: BaseFilter<T, I>,
@@ -201,10 +200,12 @@ impl<T: Transport> EthFilter<T> {
 #[cfg(test)]
 mod tests {
     use super::EthFilter;
-    use crate::api::Namespace;
-    use crate::rpc::Value;
-    use crate::transports::test::TestTransport;
-    use crate::types::{Address, FilterBuilder, Log, H256};
+    use crate::{
+        api::Namespace,
+        rpc::Value,
+        transports::test::TestTransport,
+        types::{Address, FilterBuilder, Log, H256},
+    };
     use futures::stream::StreamExt;
     use hex_literal::hex;
     use std::time::Duration;

--- a/src/api/eth_subscribe.rs
+++ b/src/api/eth_subscribe.rs
@@ -1,16 +1,17 @@
 //! `Eth` namespace, subscriptions
 
-use crate::api::Namespace;
-use crate::helpers;
-use crate::types::{BlockHeader, Filter, Log, SyncState, H256};
-use crate::{error, DuplexTransport};
+use crate::{
+    api::Namespace,
+    error, helpers,
+    types::{BlockHeader, Filter, Log, SyncState, H256},
+    DuplexTransport,
+};
 use futures::{
     task::{Context, Poll},
     Stream,
 };
 use pin_project::{pin_project, pinned_drop};
-use std::marker::PhantomData;
-use std::pin::Pin;
+use std::{marker::PhantomData, pin::Pin};
 
 /// `Eth` namespace, subscriptions
 #[derive(Debug, Clone)]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -13,21 +13,26 @@ mod traces;
 mod txpool;
 mod web3;
 
-pub use self::accounts::Accounts;
-pub use self::eth::Eth;
-pub use self::eth_filter::{BaseFilter, EthFilter};
-pub use self::eth_subscribe::{EthSubscribe, SubscriptionId, SubscriptionStream};
-pub use self::net::Net;
-pub use self::parity::Parity;
-pub use self::parity_accounts::ParityAccounts;
-pub use self::parity_set::ParitySet;
-pub use self::personal::Personal;
-pub use self::traces::Traces;
-pub use self::txpool::Txpool;
-pub use self::web3::Web3 as Web3Api;
+pub use self::{
+    accounts::Accounts,
+    eth::Eth,
+    eth_filter::{BaseFilter, EthFilter},
+    eth_subscribe::{EthSubscribe, SubscriptionId, SubscriptionStream},
+    net::Net,
+    parity::Parity,
+    parity_accounts::ParityAccounts,
+    parity_set::ParitySet,
+    personal::Personal,
+    traces::Traces,
+    txpool::Txpool,
+    web3::Web3 as Web3Api,
+};
 
-use crate::types::{Bytes, TransactionReceipt, TransactionRequest, U64};
-use crate::{confirm, error, DuplexTransport, Transport};
+use crate::{
+    confirm, error,
+    types::{Bytes, TransactionReceipt, TransactionRequest, U64},
+    DuplexTransport, Transport,
+};
 use futures::Future;
 use std::time::Duration;
 

--- a/src/api/net.rs
+++ b/src/api/net.rs
@@ -1,10 +1,6 @@
 //! `Net` namespace
 
-use crate::api::Namespace;
-use crate::helpers::CallFuture;
-use crate::types::U256;
-
-use crate::Transport;
+use crate::{api::Namespace, helpers::CallFuture, types::U256, Transport};
 
 /// `Net` namespace
 #[derive(Debug, Clone)]
@@ -44,11 +40,8 @@ impl<T: Transport> Net<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::api::Namespace;
-    use crate::rpc::Value;
-    use crate::types::U256;
-
     use super::Net;
+    use crate::{api::Namespace, rpc::Value, types::U256};
 
     rpc_test! (
       Net:version => "net_version";

--- a/src/api/parity_accounts.rs
+++ b/src/api/parity_accounts.rs
@@ -1,7 +1,9 @@
-use crate::api::Namespace;
-use crate::helpers::{self, CallFuture};
-use crate::types::{Address, H256};
-use crate::Transport;
+use crate::{
+    api::Namespace,
+    helpers::{self, CallFuture},
+    types::{Address, H256},
+    Transport,
+};
 
 /// `Parity_Accounts` namespace
 #[derive(Debug, Clone)]
@@ -60,11 +62,9 @@ impl<T: Transport> ParityAccounts<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::api::Namespace;
-    use crate::rpc::Value;
-    use ethereum_types::{Address, H256};
-
     use super::ParityAccounts;
+    use crate::{api::Namespace, rpc::Value};
+    use ethereum_types::{Address, H256};
 
     rpc_test! (
         ParityAccounts :   parity_kill_account,  &"9b776baeaf3896657a9ba0db5564623b3e0173e0".parse::<Address>().unwrap(), "123456789"

--- a/src/api/parity_set.rs
+++ b/src/api/parity_set.rs
@@ -1,8 +1,9 @@
-use crate::api::Namespace;
-use crate::helpers::{self, CallFuture};
-use crate::types::{Address, ParityPeerType, H256};
-
-use crate::Transport;
+use crate::{
+    api::Namespace,
+    helpers::{self, CallFuture},
+    types::{Address, ParityPeerType, H256},
+    Transport,
+};
 
 #[derive(Debug, Clone)]
 /// `Parity_Set` Specific API
@@ -132,9 +133,11 @@ impl<T: Transport> ParitySet<T> {
 #[cfg(test)]
 mod tests {
     use super::ParitySet;
-    use crate::api::Namespace;
-    use crate::rpc::Value;
-    use crate::types::{Address, ParityPeerInfo, ParityPeerType, PeerNetworkInfo, PeerProtocolsInfo, H256};
+    use crate::{
+        api::Namespace,
+        rpc::Value,
+        types::{Address, ParityPeerInfo, ParityPeerType, PeerNetworkInfo, PeerProtocolsInfo, H256},
+    };
 
     rpc_test! (
         ParitySet:accept_non_reserved_peers => "parity_acceptNonReservedPeers";

--- a/src/api/personal.rs
+++ b/src/api/personal.rs
@@ -1,10 +1,11 @@
 //! `Personal` namespace
 
-use crate::api::Namespace;
-use crate::helpers::{self, CallFuture};
-use crate::types::{Address, RawTransaction, TransactionRequest, H256};
-
-use crate::Transport;
+use crate::{
+    api::Namespace,
+    helpers::{self, CallFuture},
+    types::{Address, RawTransaction, TransactionRequest, H256},
+    Transport,
+};
 
 /// `Personal` namespace
 #[derive(Debug, Clone)]
@@ -80,12 +81,13 @@ impl<T: Transport> Personal<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::api::Namespace;
-    use crate::rpc::Value;
-    use crate::types::{Address, RawTransaction, TransactionRequest};
-    use hex_literal::hex;
-
     use super::Personal;
+    use crate::{
+        api::Namespace,
+        rpc::Value,
+        types::{Address, RawTransaction, TransactionRequest},
+    };
+    use hex_literal::hex;
 
     const EXAMPLE_TX: &str = r#"{
     "raw": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",

--- a/src/api/traces.rs
+++ b/src/api/traces.rs
@@ -1,7 +1,9 @@
-use crate::api::Namespace;
-use crate::helpers::{self, CallFuture};
-use crate::types::{BlockNumber, BlockTrace, Bytes, CallRequest, Index, Trace, TraceFilter, TraceType, H256};
-use crate::Transport;
+use crate::{
+    api::Namespace,
+    helpers::{self, CallFuture},
+    types::{BlockNumber, BlockTrace, Bytes, CallRequest, Index, Trace, TraceFilter, TraceType, H256},
+    Transport,
+};
 
 /// `Trace` namespace
 #[derive(Debug, Clone)]
@@ -97,10 +99,11 @@ impl<T: Transport> Traces<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::api::Namespace;
-    use crate::types::{Address, BlockNumber, BlockTrace, CallRequest, Trace, TraceFilterBuilder, TraceType, H256};
-
     use super::Traces;
+    use crate::{
+        api::Namespace,
+        types::{Address, BlockNumber, BlockTrace, CallRequest, Trace, TraceFilterBuilder, TraceType, H256},
+    };
     use hex_literal::hex;
 
     const EXAMPLE_BLOCKTRACE: &str = r#"

--- a/src/api/txpool.rs
+++ b/src/api/txpool.rs
@@ -1,9 +1,11 @@
 //! `Txpool` namespace
 
-use crate::api::Namespace;
-use crate::helpers::CallFuture;
-use crate::types::{TxpoolContentInfo, TxpoolInspectInfo, TxpoolStatus};
-use crate::Transport;
+use crate::{
+    api::Namespace,
+    helpers::CallFuture,
+    types::{TxpoolContentInfo, TxpoolInspectInfo, TxpoolStatus},
+    Transport,
+};
 
 /// `Txpool` namespace
 #[derive(Debug, Clone)]
@@ -43,10 +45,11 @@ impl<T: Transport> Txpool<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::api::Namespace;
-    use crate::types::{TxpoolContentInfo, TxpoolInspectInfo, TxpoolStatus};
-
     use super::Txpool;
+    use crate::{
+        api::Namespace,
+        types::{TxpoolContentInfo, TxpoolInspectInfo, TxpoolStatus},
+    };
 
     const EXAMPLE_CONTENT_INFO: &str = r#"{
         "pending": {

--- a/src/api/web3.rs
+++ b/src/api/web3.rs
@@ -1,10 +1,11 @@
 //! `Web3` namespace
 
-use crate::api::Namespace;
-use crate::helpers::{self, CallFuture};
-use crate::types::{Bytes, H256};
-
-use crate::Transport;
+use crate::{
+    api::Namespace,
+    helpers::{self, CallFuture},
+    types::{Bytes, H256},
+    Transport,
+};
 
 /// `Web3` namespace
 #[derive(Debug, Clone)]
@@ -40,11 +41,8 @@ impl<T: Transport> Web3<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::api::Namespace;
-    use crate::rpc::Value;
-    use crate::types::H256;
-
     use super::Web3;
+    use crate::{api::Namespace, rpc::Value, types::H256};
     use hex_literal::hex;
 
     rpc_test! (

--- a/src/confirm.rs
+++ b/src/confirm.rs
@@ -1,8 +1,11 @@
 //! Easy to use utilities for confirmations.
 
-use crate::api::{Eth, EthFilter, Namespace};
-use crate::types::{Bytes, TransactionReceipt, TransactionRequest, H256, U64};
-use crate::{error, Transport};
+use crate::{
+    api::{Eth, EthFilter, Namespace},
+    error,
+    types::{Bytes, TransactionReceipt, TransactionRequest, H256, U64},
+    Transport,
+};
 use futures::{Future, StreamExt};
 use std::time::Duration;
 
@@ -117,9 +120,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::send_transaction_with_confirmation;
-    use crate::rpc::Value;
-    use crate::transports::test::TestTransport;
-    use crate::types::{Address, TransactionReceipt, TransactionRequest, H256, U64};
+    use crate::{
+        rpc::Value,
+        transports::test::TestTransport,
+        types::{Address, TransactionReceipt, TransactionRequest, H256, U64},
+    };
     use serde_json::json;
     use std::time::Duration;
 

--- a/src/contract/deploy.rs
+++ b/src/contract/deploy.rs
@@ -1,16 +1,15 @@
 //! Contract deployment utilities
 
+use crate::{
+    api::{Eth, Namespace},
+    confirm,
+    contract::{tokens::Tokenize, Contract, Options},
+    error,
+    types::{Address, Bytes, TransactionReceipt, TransactionRequest},
+    Transport,
+};
 use futures::{Future, TryFutureExt};
-use std::collections::HashMap;
-use std::time;
-
-use crate::api::{Eth, Namespace};
-use crate::confirm;
-use crate::contract::tokens::Tokenize;
-use crate::contract::{Contract, Options};
-use crate::error;
-use crate::types::{Address, Bytes, TransactionReceipt, TransactionRequest};
-use crate::Transport;
+use std::{collections::HashMap, time};
 
 pub use crate::contract::error::deploy::Error;
 
@@ -162,11 +161,13 @@ impl<T: Transport> Builder<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::api::{self, Namespace};
-    use crate::contract::{Contract, Options};
-    use crate::rpc;
-    use crate::transports::test::TestTransport;
-    use crate::types::{Address, U256};
+    use crate::{
+        api::{self, Namespace},
+        contract::{Contract, Options},
+        rpc,
+        transports::test::TestTransport,
+        types::{Address, U256},
+    };
     use serde_json::Value;
     use std::collections::HashMap;
 

--- a/src/contract/error.rs
+++ b/src/contract/error.rs
@@ -1,9 +1,8 @@
 //! Contract call/query error.
 
-use ethabi::Error as EthError;
-
 use crate::error::Error as ApiError;
 use derive_more::{Display, From};
+use ethabi::Error as EthError;
 
 /// Contract error.
 #[derive(Debug, Display, From)]
@@ -34,8 +33,7 @@ impl std::error::Error for Error {
 }
 
 pub mod deploy {
-    use crate::error::Error as ApiError;
-    use crate::types::H256;
+    use crate::{error::Error as ApiError, types::H256};
     use derive_more::{Display, From};
 
     /// Contract deployment error.

--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -1,13 +1,15 @@
 //! Ethereum Contract Interface
 
-use crate::api::{Eth, Namespace};
-use crate::confirm;
-use crate::contract::tokens::{Detokenize, Tokenize};
-use crate::types::{
-    Address, BlockId, Bytes, CallRequest, FilterBuilder, TransactionCondition, TransactionReceipt, TransactionRequest,
-    H256, U256,
+use crate::{
+    api::{Eth, Namespace},
+    confirm,
+    contract::tokens::{Detokenize, Tokenize},
+    types::{
+        Address, BlockId, Bytes, CallRequest, FilterBuilder, TransactionCondition, TransactionReceipt,
+        TransactionRequest, H256, U256,
+    },
+    Transport,
 };
-use crate::Transport;
 use std::{collections::HashMap, hash::Hash, time};
 
 pub mod deploy;
@@ -278,11 +280,9 @@ impl<T: Transport> Contract<T> {
 
 #[cfg(feature = "signing")]
 mod contract_signing {
-    use crate::api::Accounts;
-    use crate::signing;
-    use crate::types::TransactionParameters;
-
     use super::*;
+    use crate::{api::Accounts, signing, types::TransactionParameters};
+
     impl<T: Transport> Contract<T> {
         /// Execute a signed contract function and wait for confirmations
         pub async fn signed_call_with_confirmations(
@@ -331,11 +331,13 @@ mod contract_signing {
 #[cfg(test)]
 mod tests {
     use super::{Contract, Options};
-    use crate::api::{self, Namespace};
-    use crate::rpc;
-    use crate::transports::test::TestTransport;
-    use crate::types::{Address, BlockId, BlockNumber, H256, U256};
-    use crate::Transport;
+    use crate::{
+        api::{self, Namespace},
+        rpc,
+        transports::test::TestTransport,
+        types::{Address, BlockId, BlockNumber, H256, U256},
+        Transport,
+    };
 
     fn contract<T: Transport>(transport: &T) -> Contract<&T> {
         let eth = api::Eth::new(transport);

--- a/src/contract/tokens.rs
+++ b/src/contract/tokens.rs
@@ -1,7 +1,9 @@
 //! Contract Functions Output types.
 
-use crate::contract::error::Error;
-use crate::types::{Address, Bytes, BytesArray, H256, U128, U256};
+use crate::{
+    contract::error::Error,
+    types::{Address, Bytes, BytesArray, H256, U128, U256},
+};
 use arrayvec::ArrayVec;
 use ethabi::Token;
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,14 +1,12 @@
 //! Web3 helpers.
 
-use std::marker::PhantomData;
-use std::pin::Pin;
-
 use crate::{error, rpc};
 use futures::{
     task::{Context, Poll},
     Future,
 };
 use pin_project::pin_project;
+use std::{marker::PhantomData, pin::Pin};
 
 /// Takes any type which is deserializable from rpc::Value and such a value and
 /// yields the deserialized value

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,10 @@ pub mod signing;
 pub mod transports;
 pub mod types;
 
-pub use crate::api::Web3;
-pub use crate::error::{Error, Result};
+pub use crate::{
+    api::Web3,
+    error::{Error, Result},
+};
 
 /// Assigned RequestId
 pub type RequestId = usize;

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -29,13 +29,13 @@ pub use feature_gated::*;
 #[cfg(feature = "signing")]
 mod feature_gated {
     use super::*;
-
-    use secp256k1::recovery::{RecoverableSignature, RecoveryId};
-    pub(crate) use secp256k1::SecretKey;
-    use secp256k1::{Message, PublicKey, Secp256k1};
-    use std::ops::Deref;
-
     use crate::types::Address;
+    pub(crate) use secp256k1::SecretKey;
+    use secp256k1::{
+        recovery::{RecoverableSignature, RecoveryId},
+        Message, PublicKey, Secp256k1,
+    };
+    use std::ops::Deref;
 
     /// A trait representing ethereum-compatible key with signing capabilities.
     ///

--- a/src/transports/batch.rs
+++ b/src/transports/batch.rs
@@ -1,18 +1,16 @@
 //! Batching Transport
 
-use crate::error::{self, Error};
-use crate::rpc;
-use crate::{BatchTransport, RequestId, Transport};
-use futures::channel::oneshot;
+use crate::{
+    error::{self, Error},
+    rpc, BatchTransport, RequestId, Transport,
+};
 use futures::{
+    channel::oneshot,
     task::{Context, Poll},
     Future, FutureExt,
 };
 use parking_lot::Mutex;
-use std::collections::BTreeMap;
-use std::mem;
-use std::pin::Pin;
-use std::sync::Arc;
+use std::{collections::BTreeMap, mem, pin::Pin, sync::Arc};
 
 type Pending = oneshot::Sender<error::Result<rpc::Value>>;
 type PendingRequests = Arc<Mutex<BTreeMap<RequestId, Pending>>>;

--- a/src/transports/eip_1193.rs
+++ b/src/transports/eip_1193.rs
@@ -4,21 +4,20 @@
 //! EIP-1193 providers like MetaMask. It's intended for use with Rust's
 //! WebAssembly target.
 
-use crate::api::SubscriptionId;
-use crate::types::{Address, U256};
-use crate::{error, DuplexTransport, Error, RequestId, Transport};
-use futures::channel::mpsc;
-use futures::future::LocalBoxFuture;
-use futures::Stream;
+use crate::{
+    api::SubscriptionId,
+    error,
+    types::{Address, U256},
+    DuplexTransport, Error, RequestId, Transport,
+};
+use futures::{channel::mpsc, future::LocalBoxFuture, Stream};
 use jsonrpc_core::types::request::{Call, MethodCall};
-use serde::de::value::StringDeserializer;
-use serde::de::IntoDeserializer;
-use serde::Deserialize;
-use std::cell::RefCell;
-use std::collections::BTreeMap;
-use std::rc::Rc;
-use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
+use serde::{
+    de::{value::StringDeserializer, IntoDeserializer},
+    Deserialize,
+};
+use std::{cell::RefCell, collections::BTreeMap, rc::Rc};
+use wasm_bindgen::{prelude::*, JsCast};
 
 type Subscriptions = Rc<RefCell<BTreeMap<SubscriptionId, mpsc::UnboundedSender<serde_json::Value>>>>;
 

--- a/src/transports/http.rs
+++ b/src/transports/http.rs
@@ -1,18 +1,21 @@
 //! HTTP Transport
 
-use crate::error;
-use crate::helpers;
-use crate::rpc;
-use crate::{BatchTransport, Error, RequestId, Transport};
-use futures::task::{Context, Poll};
-use futures::{self, Future, FutureExt, StreamExt};
+use crate::{error, helpers, rpc, BatchTransport, Error, RequestId, Transport};
+use futures::{
+    self,
+    task::{Context, Poll},
+    Future, FutureExt, StreamExt,
+};
 use hyper::header::HeaderValue;
-use std::env;
-use std::fmt;
-use std::ops::Deref;
-use std::pin::Pin;
-use std::sync::atomic::{self, AtomicUsize};
-use std::sync::Arc;
+use std::{
+    env, fmt,
+    ops::Deref,
+    pin::Pin,
+    sync::{
+        atomic::{self, AtomicUsize},
+        Arc,
+    },
+};
 use url::Url;
 
 impl From<hyper::Error> for Error {

--- a/src/transports/test.rs
+++ b/src/transports/test.rs
@@ -1,13 +1,11 @@
 //! Test Transport
 
-use crate::error::{self, Error};
-use crate::helpers;
-use crate::rpc;
-use crate::{RequestId, Transport};
+use crate::{
+    error::{self, Error},
+    helpers, rpc, RequestId, Transport,
+};
 use futures::future::{self, BoxFuture, FutureExt};
-use std::cell::RefCell;
-use std::collections::VecDeque;
-use std::rc::Rc;
+use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 
 type Result<T> = BoxFuture<'static, error::Result<T>>;
 

--- a/src/transports/ws.rs
+++ b/src/transports/ws.rs
@@ -1,25 +1,23 @@
 //! WebSocket Transport
 
-use std::collections::BTreeMap;
-use std::marker::Unpin;
-use std::sync::{atomic, Arc};
-use std::{fmt, pin::Pin};
-
 use self::compat::{TcpStream, TlsStream};
-use crate::api::SubscriptionId;
-use crate::error;
-use crate::helpers;
-use crate::rpc;
-use crate::{BatchTransport, DuplexTransport, Error, RequestId, Transport};
-use futures::channel::{mpsc, oneshot};
+use crate::{api::SubscriptionId, error, helpers, rpc, BatchTransport, DuplexTransport, Error, RequestId, Transport};
 use futures::{
+    channel::{mpsc, oneshot},
     task::{Context, Poll},
-    Future, FutureExt, Stream, StreamExt,
+    AsyncRead, AsyncWrite, Future, FutureExt, Stream, StreamExt,
 };
-use futures::{AsyncRead, AsyncWrite};
-
-use soketto::connection;
-use soketto::handshake::{Client, ServerResponse};
+use soketto::{
+    connection,
+    handshake::{Client, ServerResponse},
+};
+use std::{
+    collections::BTreeMap,
+    fmt,
+    marker::Unpin,
+    pin::Pin,
+    sync::{atomic, Arc},
+};
 use url::Url;
 
 impl From<soketto::handshake::Error> for Error {
@@ -437,8 +435,7 @@ impl DuplexTransport for WebSocket {
 #[cfg(feature = "ws-async-std")]
 #[doc(hidden)]
 pub mod compat {
-    pub use async_std::net::TcpListener;
-    pub use async_std::net::TcpStream;
+    pub use async_std::net::{TcpListener, TcpStream};
     /// TLS stream type for async-std runtime.
     #[cfg(feature = "ws-tls-async-std")]
     pub type TlsStream = async_native_tls::TlsStream<TcpStream>;
@@ -472,9 +469,11 @@ pub mod compat {
     #[cfg(not(feature = "ws-tls-tokio"))]
     pub type TlsStream = TcpStream;
 
-    use std::io;
-    use std::pin::Pin;
-    use std::task::{Context, Poll};
+    use std::{
+        io,
+        pin::Pin,
+        task::{Context, Poll},
+    };
 
     /// Create new TcpStream object.
     pub async fn raw_tcp_stream(addrs: String) -> io::Result<tokio::net::TcpStream> {
@@ -533,8 +532,10 @@ pub mod compat {
 mod tests {
     use super::*;
     use crate::{rpc, Transport};
-    use futures::io::{BufReader, BufWriter};
-    use futures::StreamExt;
+    use futures::{
+        io::{BufReader, BufWriter},
+        StreamExt,
+    };
     use soketto::handshake;
 
     #[test]

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -1,5 +1,7 @@
-use serde::de::{Error, Unexpected, Visitor};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{
+    de::{Error, Unexpected, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
 use std::fmt;
 
 /// Raw bytes wrapper

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -17,30 +17,32 @@ mod txpool;
 mod uint;
 mod work;
 
-pub use self::block::{Block, BlockHeader, BlockId, BlockNumber};
-pub use self::bytes::Bytes;
-pub use self::bytes_array::BytesArray;
-pub use self::log::{Filter, FilterBuilder, Log};
-pub use self::parity_peers::{
-    EthProtocolInfo, ParityPeerInfo, ParityPeerType, PeerNetworkInfo, PeerProtocolsInfo, PipProtocolInfo,
+pub use self::{
+    block::{Block, BlockHeader, BlockId, BlockNumber},
+    bytes::Bytes,
+    bytes_array::BytesArray,
+    log::{Filter, FilterBuilder, Log},
+    parity_peers::{
+        EthProtocolInfo, ParityPeerInfo, ParityPeerType, PeerNetworkInfo, PeerProtocolsInfo, PipProtocolInfo,
+    },
+    recovery::{Recovery, RecoveryMessage},
+    signed::{SignedData, SignedTransaction, TransactionParameters},
+    sync_state::{SyncInfo, SyncState},
+    trace_filtering::{
+        Action, ActionType, Call, CallResult, CallType, Create, CreateResult, Res, Reward, RewardType, Suicide, Trace,
+        TraceFilter, TraceFilterBuilder,
+    },
+    traces::{
+        AccountDiff, BlockTrace, ChangedType, Diff, MemoryDiff, StateDiff, StorageDiff, TraceType, TransactionTrace,
+        VMExecutedOperation, VMOperation, VMTrace,
+    },
+    transaction::{RawTransaction, Receipt as TransactionReceipt, Transaction},
+    transaction_id::TransactionId,
+    transaction_request::{CallRequest, TransactionCondition, TransactionRequest},
+    txpool::{TxpoolContentInfo, TxpoolInspectInfo, TxpoolStatus},
+    uint::{H128, H160, H2048, H256, H512, H520, H64, U128, U256, U64},
+    work::Work,
 };
-pub use self::recovery::{Recovery, RecoveryMessage};
-pub use self::signed::{SignedData, SignedTransaction, TransactionParameters};
-pub use self::sync_state::{SyncInfo, SyncState};
-pub use self::trace_filtering::{
-    Action, ActionType, Call, CallResult, CallType, Create, CreateResult, Res, Reward, RewardType, Suicide, Trace,
-    TraceFilter, TraceFilterBuilder,
-};
-pub use self::traces::{
-    AccountDiff, BlockTrace, ChangedType, Diff, MemoryDiff, StateDiff, StorageDiff, TraceType, TransactionTrace,
-    VMExecutedOperation, VMOperation, VMTrace,
-};
-pub use self::transaction::{RawTransaction, Receipt as TransactionReceipt, Transaction};
-pub use self::transaction_id::TransactionId;
-pub use self::transaction_request::{CallRequest, TransactionCondition, TransactionRequest};
-pub use self::txpool::{TxpoolContentInfo, TxpoolInspectInfo, TxpoolStatus};
-pub use self::uint::{H128, H160, H2048, H256, H512, H520, H64, U128, U256, U64};
-pub use self::work::Work;
 
 /// Address
 pub type Address = H160;

--- a/src/types/recovery.rs
+++ b/src/types/recovery.rs
@@ -1,6 +1,8 @@
 use crate::types::{SignedData, SignedTransaction, H256};
-use std::error::Error;
-use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::{
+    error::Error,
+    fmt::{Display, Formatter, Result as FmtResult},
+};
 
 /// Data for recovering the public address of signed data.
 ///

--- a/src/types/sync_state.rs
+++ b/src/types/sync_state.rs
@@ -1,7 +1,9 @@
 use crate::types::U256;
-use serde::de::{Deserializer, Error};
-use serde::ser::Serializer;
-use serde::{Deserialize, Serialize};
+use serde::{
+    de::{Deserializer, Error},
+    ser::Serializer,
+    Deserialize, Serialize,
+};
 
 /// Information about current blockchain syncing operations.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -120,8 +120,7 @@ pub struct RawTransactionDetails {
 
 #[cfg(test)]
 mod tests {
-    use super::RawTransaction;
-    use super::Receipt;
+    use super::{RawTransaction, Receipt};
 
     #[test]
     fn test_deserialize_receipt() {

--- a/src/types/transaction_request.rs
+++ b/src/types/transaction_request.rs
@@ -72,9 +72,8 @@ pub enum TransactionCondition {
 
 #[cfg(test)]
 mod tests {
-    use hex_literal::hex;
-
     use super::{Address, CallRequest, TransactionCondition, TransactionRequest};
+    use hex_literal::hex;
 
     #[test]
     fn should_serialize_call_request() {

--- a/src/types/txpool.rs
+++ b/src/types/txpool.rs
@@ -1,5 +1,4 @@
-use crate::types::U64;
-use crate::types::{Address, Transaction};
+use crate::types::{Address, Transaction, U64};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 

--- a/src/types/work.rs
+++ b/src/types/work.rs
@@ -1,6 +1,5 @@
 use crate::types::{H256, U256};
-use serde::de::Error;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{self, Value};
 
 /// Miner's work package


### PR DESCRIPTION
The style of imports has not yet been decided on in the wider Rust community - there are at least 4 competing proposals right now.

However, there is only one that has been implemented in rustfmt: one use statement per crate. Opting for this style is the only way to get automated and reproducible use statements.