### PR TITLE
add method to import private key to node

### DIFF
--- a/src/api/personal.rs
+++ b/src/api/personal.rs
@@ -81,7 +81,7 @@ impl<T: Transport> Personal<T> {
     /// Imports a raw key and protects it with the given password.
     /// Returns the address of created account.
     pub fn import_raw_key(&self, private_key: &[u8; 32], password: &str) -> CallFuture<Address, T::Out> {
-      let private_key = hex::encode(private_key);
+        let private_key = hex::encode(private_key);
         let private_key = helpers::serialize(&private_key);
         let password = helpers::serialize(&password);
 
@@ -166,7 +166,7 @@ mod tests {
     );
 
     rpc_test! {
-      Personal:import_raw_key, "0000000000000000000000000000000000000000000000000000000000000123", "hunter2" =>
+      Personal:import_raw_key, &[0u8; 32], "hunter2" =>
       "personal_importRawKey", vec![r#""0000000000000000000000000000000000000000000000000000000000000123""#, r#""hunter2""#];
       Value::String("0x0000000000000000000000000000000000000123".into()) => Address::from_low_u64_be(0x123)
     }

--- a/src/api/personal.rs
+++ b/src/api/personal.rs
@@ -163,4 +163,10 @@ mod tests {
       ::serde_json::from_str(EXAMPLE_TX).unwrap()
       => ::serde_json::from_str::<RawTransaction>(EXAMPLE_TX).unwrap()
     );
+
+    rpc_test! {
+      Personal:import_private_key, "0000000000000000000000000000000000000000000000000000000000000123", "hunter2" =>
+      "personal_importRawKey", vec![r#""0000000000000000000000000000000000000000000000000000000000000123""#, r#""hunter2""#];
+      Value::String("0x0000000000000000000000000000000000000123".into()) => Address::from_low_u64_be(0x123)
+    }
 }

--- a/src/api/personal.rs
+++ b/src/api/personal.rs
@@ -77,6 +77,18 @@ impl<T: Transport> Personal<T> {
                 .execute("personal_signTransaction", vec![transaction, password]),
         )
     }
+
+    /// Imports a raw key and protects it with the given password.
+    /// Returns the address of created account.
+    pub fn import_private_key(&self, private_key: &str, password: &str) -> CallFuture<Address, T::Out> {
+      let private_key = helpers::serialize(&private_key);
+      let password = helpers::serialize(&password);
+
+      CallFuture::new(
+          self.transport
+              .execute("personal_importRawKey", vec![private_key, password]),
+      )
+    }
 }
 
 #[cfg(test)]

--- a/src/api/personal.rs
+++ b/src/api/personal.rs
@@ -80,7 +80,8 @@ impl<T: Transport> Personal<T> {
 
     /// Imports a raw key and protects it with the given password.
     /// Returns the address of created account.
-    pub fn import_raw_key(&self, private_key: &str, password: &str) -> CallFuture<Address, T::Out> {
+    pub fn import_raw_key(&self, private_key: &[u8; 32], password: &str) -> CallFuture<Address, T::Out> {
+      let private_key = hex::encode(private_key);
         let private_key = helpers::serialize(&private_key);
         let password = helpers::serialize(&password);
 

--- a/src/api/personal.rs
+++ b/src/api/personal.rs
@@ -167,7 +167,7 @@ mod tests {
 
     rpc_test! {
       Personal:import_raw_key, &[0u8; 32], "hunter2" =>
-      "personal_importRawKey", vec![r#""0000000000000000000000000000000000000000000000000000000000000123""#, r#""hunter2""#];
+      "personal_importRawKey", vec![r#""0000000000000000000000000000000000000000000000000000000000000000""#, r#""hunter2""#];
       Value::String("0x0000000000000000000000000000000000000123".into()) => Address::from_low_u64_be(0x123)
     }
 }

--- a/src/api/personal.rs
+++ b/src/api/personal.rs
@@ -80,7 +80,7 @@ impl<T: Transport> Personal<T> {
 
     /// Imports a raw key and protects it with the given password.
     /// Returns the address of created account.
-    pub fn import_private_key(&self, private_key: &str, password: &str) -> CallFuture<Address, T::Out> {
+    pub fn import_raw_key(&self, private_key: &str, password: &str) -> CallFuture<Address, T::Out> {
         let private_key = helpers::serialize(&private_key);
         let password = helpers::serialize(&password);
 
@@ -165,7 +165,7 @@ mod tests {
     );
 
     rpc_test! {
-      Personal:import_private_key, "0000000000000000000000000000000000000000000000000000000000000123", "hunter2" =>
+      Personal:import_raw_key, "0000000000000000000000000000000000000000000000000000000000000123", "hunter2" =>
       "personal_importRawKey", vec![r#""0000000000000000000000000000000000000000000000000000000000000123""#, r#""hunter2""#];
       Value::String("0x0000000000000000000000000000000000000123".into()) => Address::from_low_u64_be(0x123)
     }

--- a/src/api/personal.rs
+++ b/src/api/personal.rs
@@ -81,13 +81,13 @@ impl<T: Transport> Personal<T> {
     /// Imports a raw key and protects it with the given password.
     /// Returns the address of created account.
     pub fn import_private_key(&self, private_key: &str, password: &str) -> CallFuture<Address, T::Out> {
-      let private_key = helpers::serialize(&private_key);
-      let password = helpers::serialize(&password);
+        let private_key = helpers::serialize(&private_key);
+        let password = helpers::serialize(&password);
 
-      CallFuture::new(
-          self.transport
-              .execute("personal_importRawKey", vec![private_key, password]),
-      )
+        CallFuture::new(
+            self.transport
+                .execute("personal_importRawKey", vec![private_key, password]),
+        )
     }
 }
 


### PR DESCRIPTION
I treat my Ethereum Node as ephemeral (private chain, using a dedicated node for sealing and Kubernetes members to process transactions). Private keys are stored in a HashiCorp Vault to pull in to the ephemeral Ethereum Node when needed.

That written, I need access to the private keys to store in HCV. This snippet just exposes the `importRawKey` method on the Ethereum node to an application via `web3`.

I'm a novice Rust user and had some trouble getting the `private_key` in a format usable for this call. I initially had this method accept an `H256`, but couldn't figure out how to easily output the contents without the `0x` so that Geth would accept it. I settled on using `&hex::encode(&bytes)` to generate the argument as an `&str` for the method here.