### PR TITLE
feat: support parity_pendingTransactions

### DIFF
--- a/src/api/parity.rs
+++ b/src/api/parity.rs
@@ -63,18 +63,29 @@ mod tests {
     use hex_literal::hex;
 
     const EXAMPLE_PENDING_TX: &str = r#"{
-    "hash": "0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b",
-    "nonce": "0x0",
     "blockHash": null,
     "blockNumber": null,
+    "creates": null,
+    "from": "0xee3ea02840129123d5397f91be0391283a25bc7d",
+    "gas": "0x23b58",
+    "gasPrice": "0xba43b7400",
+    "hash": "0x160b3c30ab1cf5871083f97ee1cee3901cfba3b0a2258eb337dd20a7e816b36e",
+    "input": "0x095ea7b3000000000000000000000000bf4ed7b27f1d666546e30d74d50d173d20bca75400000000000000000000000000002643c948210b4bd99244ccd64d5555555555",
+    "condition": {
+    "block": 1
+    },
+    "chainId": 1,
+    "nonce": "0x5",
+    "publicKey": "0x96157302dade55a1178581333e57d60ffe6fdf5a99607890456a578b4e6b60e335037d61ed58aa4180f9fd747dc50d44a7924aa026acbfb988b5062b629d6c36",
+    "r": "0x92e8beb19af2bad0511d516a86e77fa73004c0811b2173657a55797bdf8558e1",
+    "raw": "0xf8aa05850ba43b740083023b5894bb9bc244d798123fde783fcc1c72d3bb8c18941380b844095ea7b3000000000000000000000000bf4ed7b27f1d666546e30d74d50d173d20bca75400000000000000000000000000002643c948210b4bd99244ccd64d555555555526a092e8beb19af2bad0511d516a86e77fa73004c0811b2173657a55797bdf8558e1a062b4d4d125bbcb9c162453bc36ca156537543bb4414d59d1805d37fb63b351b8",
+    "s": "0x62b4d4d125bbcb9c162453bc36ca156537543bb4414d59d1805d37fb63b351b8",
+    "standardV": "0x1",
+    "to": "0xbb9bc244d798123fde783fcc1c72d3bb8c189413",
     "transactionIndex": null,
-    "from": "0x407d73d8a49eeb85d32cf465507dd71d507100c1",
-    "to":   "0x85dd43d8a49eeb85d32cf465507dd71d507100c1",
-    "value": "0x7f110",
-    "gas": "0x7f110",
-    "gasPrice": "0x09184e72a000",
-    "input": "0x603880600c6000396000f300603880600c6000396000f3603880600c6000396000f360"
-  }"#;
+    "v": "0x26",
+    "value": "0x0"
+}"#;
 
     rpc_test!(
         Parity:call,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -5,6 +5,7 @@ mod bytes;
 mod bytes_array;
 mod log;
 mod parity_peers;
+mod parity_pending_transaction;
 mod recovery;
 mod signed;
 mod sync_state;
@@ -24,6 +25,9 @@ pub use self::{
     log::{Filter, FilterBuilder, Log},
     parity_peers::{
         EthProtocolInfo, ParityPeerInfo, ParityPeerType, PeerNetworkInfo, PeerProtocolsInfo, PipProtocolInfo,
+    },
+    parity_pending_transaction::{
+        FilterCondition, ParityPendingTransactionFilter, ParityPendingTransactionFilterBuilder, ToFilter,
     },
     recovery::{Recovery, RecoveryMessage},
     signed::{SignedData, SignedTransaction, TransactionParameters},

--- a/src/types/parity_pending_transaction.rs
+++ b/src/types/parity_pending_transaction.rs
@@ -1,0 +1,135 @@
+use serde::{
+    ser::{SerializeMap, Serializer},
+    Serialize,
+};
+
+use super::{Address, U256, U64};
+
+/// Condition to filter pending transactions
+#[derive(Clone)]
+pub enum FilterCondition<T> {
+    /// Lower Than
+    Lt(T),
+    /// Equal
+    Eq(T),
+    /// Greater Than
+    Gt(T),
+}
+
+/// To Filter
+#[derive(Clone)]
+pub enum ToFilter {
+    /// Address
+    Address(Address),
+    /// Action (i.e. contract creation)
+    Action,
+}
+
+/// Filter for pending transactions (only openethereum/Parity)
+#[derive(Clone, Default, Serialize)]
+pub struct ParityPendingTransactionFilter {
+    /// From address
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from: Option<FilterCondition<Address>>,
+    /// To address or action, i.e. contract creation
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to: Option<ToFilter>,
+    /// Gas
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gas: Option<FilterCondition<U64>>,
+    /// Gas Price
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gas_price: Option<FilterCondition<U64>>,
+    /// Value
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<FilterCondition<U256>>,
+    /// Nonce
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nonce: Option<FilterCondition<U256>>,
+}
+
+impl<T> Serialize for FilterCondition<T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(1))?;
+        match self {
+            Self::Lt(v) => map.serialize_entry("lt", v),
+            Self::Eq(v) => map.serialize_entry("eq", v),
+            Self::Gt(v) => map.serialize_entry("gt", v),
+        }?;
+        map.end()
+    }
+}
+
+impl Serialize for ToFilter {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(1))?;
+
+        match self {
+            Self::Address(a) => map.serialize_entry("eq", a)?,
+            Self::Action => map.serialize_entry("action", "contract_creation")?,
+        }
+        map.end()
+    }
+}
+
+/// Filter Builder
+#[derive(Default, Clone)]
+pub struct ParityPendingTransactionFilterBuilder {
+    filter: ParityPendingTransactionFilter,
+}
+
+impl ParityPendingTransactionFilterBuilder {
+    /// Sets `from`
+    pub fn from(mut self, from: FilterCondition<Address>) -> Self {
+        if let FilterCondition::Eq(_) = from {
+            self.filter.from = Some(from);
+            self
+        } else {
+            panic!("Must use FilterConditon::Eq to apply filter for `from` address")
+        }
+    }
+
+    /// Sets `to`
+    pub fn to(mut self, to_or_action: ToFilter) -> Self {
+        self.filter.to = Some(to_or_action);
+        self
+    }
+
+    /// Sets `gas`
+    pub fn gas(mut self, gas: FilterCondition<U64>) -> Self {
+        self.filter.gas = Some(gas);
+        self
+    }
+
+    /// Sets `gas_price`
+    pub fn gas_price(mut self, gas_price: FilterCondition<U64>) -> Self {
+        self.filter.gas_price = Some(gas_price);
+        self
+    }
+
+    /// Sets `value`
+    pub fn value(mut self, value: FilterCondition<U256>) -> Self {
+        self.filter.value = Some(value);
+        self
+    }
+
+    /// Sets `nonce`
+    pub fn nonce(mut self, nonce: FilterCondition<U256>) -> Self {
+        self.filter.nonce = Some(nonce);
+        self
+    }
+
+    /// Returns filter
+    pub fn build(&self) -> ParityPendingTransactionFilter {
+        self.filter.clone()
+    }
+}


### PR DESCRIPTION
Adding support for [`parity_pendingTransactions`](https://openethereum.github.io/JSONRPC-parity-module#parity_pendingtransactions). Implements https://github.com/tomusdrw/rust-web3/issues/440

Applying a pending transaction filter is blocked by https://github.com/openethereum/openethereum/issues/159. However, omitting a filter gives a full list of pending transactions as expected. This has been tested with a synced openethereum node.

Would love to get some feedback!