### PR TITLE
Allow tokenization of tuples

### DIFF
--- a/examples/contract.rs
+++ b/examples/contract.rs
@@ -28,8 +28,10 @@ async fn main() -> web3::contract::Result<()> {
         )
         .await?;
 
-    let result = contract.query("balanceOf", (my_account,), None, Options::default(), None);
-    let balance_of: U256 = result.await?;
+    let result: (U256,) = contract
+        .query("balanceOf", (my_account,), None, Options::default(), None)
+        .await?;
+    let balance_of = result.0;
     assert_eq!(balance_of, 1_000_000.into());
 
     // Accessing existing contract
@@ -40,8 +42,10 @@ async fn main() -> web3::contract::Result<()> {
         include_bytes!("../src/contract/res/token.json"),
     )?;
 
-    let result = contract.query("balanceOf", (my_account,), None, Options::default(), None);
-    let balance_of: U256 = result.await?;
+    let result: (U256,) = contract
+        .query("balanceOf", (my_account,), None, Options::default(), None)
+        .await?;
+    let balance_of = result.0;
     assert_eq!(balance_of, 1_000_000.into());
 
     Ok(())

--- a/examples/contract_storage.rs
+++ b/examples/contract_storage.rs
@@ -31,8 +31,8 @@ async fn main() -> web3::contract::Result<()> {
     println!("Deployed at: {}", contract.address());
 
     // interact with the contract
-    let result = contract.query("get", (), None, Options::default(), None);
-    let storage: U256 = result.await?;
+    let result: (U256,) = contract.query("get", (), None, Options::default(), None).await?;
+    let storage = result.0;
     println!("Get Storage: {}", storage);
 
     // Change state of the contract
@@ -43,8 +43,8 @@ async fn main() -> web3::contract::Result<()> {
     std::thread::sleep(std::time::Duration::from_secs(5));
 
     // View changes made
-    let result = contract.query("get", (), None, Options::default(), None);
-    let storage: U256 = result.await?;
+    let result: (U256,) = contract.query("get", (), None, Options::default(), None).await?;
+    let storage = result.0;
     println!("Get again: {}", storage);
 
     Ok(())

--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -370,7 +370,7 @@ mod tests {
         let mut transport = TestTransport::default();
         transport.set_response(rpc::Value::String("0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000c48656c6c6f20576f726c64210000000000000000000000000000000000000000".into()));
 
-        let result: String = {
+        let result: (String,) = {
             let token = contract(&transport);
 
             // when
@@ -393,7 +393,7 @@ mod tests {
             ],
         );
         transport.assert_no_more_requests();
-        assert_eq!(result, "Hello World!".to_owned());
+        assert_eq!(result.0, "Hello World!".to_owned());
     }
 
     #[test]
@@ -402,7 +402,7 @@ mod tests {
         let mut transport = TestTransport::default();
         transport.set_response(rpc::Value::String("0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000c48656c6c6f20576f726c64210000000000000000000000000000000000000000".into()));
 
-        let result: String = {
+        let result: (String,) = {
             let token = contract(&transport);
 
             // when
@@ -425,7 +425,7 @@ mod tests {
             ],
         );
         transport.assert_no_more_requests();
-        assert_eq!(result, "Hello World!".to_owned());
+        assert_eq!(result.0, "Hello World!".to_owned());
     }
 
     #[test]
@@ -434,7 +434,7 @@ mod tests {
         let mut transport = TestTransport::default();
         transport.set_response(rpc::Value::String("0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000c48656c6c6f20576f726c64210000000000000000000000000000000000000000".into()));
 
-        let result: String = {
+        let result: (String,) = {
             let token = contract(&transport);
 
             // when
@@ -453,7 +453,7 @@ mod tests {
         // then
         transport.assert_request("eth_call", &["{\"data\":\"0x06fdde03\",\"from\":\"0x0000000000000000000000000000000000000005\",\"gasPrice\":\"0x989680\",\"to\":\"0x0000000000000000000000000000000000000001\"}".into(), "\"latest\"".into()]);
         transport.assert_no_more_requests();
-        assert_eq!(result, "Hello World!".to_owned());
+        assert_eq!(result.0, "Hello World!".to_owned());
     }
 
     #[test]
@@ -504,13 +504,13 @@ mod tests {
             "0x0000000000000000000000000000000000000000000000000000000000000020".into(),
         ));
 
-        let result: U256 = {
+        let result: (U256,) = {
             let token = contract(&transport);
 
             // when
             futures::executor::block_on(token.query(
                 "balanceOf",
-                Address::from_low_u64_be(5),
+                (Address::from_low_u64_be(5),),
                 None,
                 Options::default(),
                 None,
@@ -521,6 +521,6 @@ mod tests {
         // then
         transport.assert_request("eth_call", &["{\"data\":\"0x70a082310000000000000000000000000000000000000000000000000000000000000005\",\"to\":\"0x0000000000000000000000000000000000000001\"}".into(), "\"latest\"".into()]);
         transport.assert_no_more_requests();
-        assert_eq!(result, 0x20.into());
+        assert_eq!(result.0, 0x20.into());
     }
 }


### PR DESCRIPTION
With solidity abi v2 it has become possible to pass structs directly as
arguments to functions. A struct containing types T0 and T1 is encoded
as a tuple (T0, T1).

In the current state of rust-web3 it is not possible to pass tuples
because of the way the tokenization related traits are set up. We have
Tokenizable which is implemented for basic types like i32 and for arrays
of basic types but not for tuples of Tokenizable. Tokenize is
implemented on tuples of Tokenizable but not tuples of Tokenize so
nesting of tuples is not possible.

This PR allows tokenization of tuple types by implementing Tokenizable
on tuples of Tokenizable. In order for this to not introduce trait
ambiguity (which the compiler also notices) we have to remove the
implementations of Detokenize and Tokenize on a single T: Tokenizable.
This would be ambiguous because it would not be clear whether a (t0, t1)
refers to two function arguments or a single tuple function argument.

This last part means this is a (small) breaking change as function
arguments and return types (for example in Contract::query) now always
have to be tuples (or Vec<Token>) and cannot be single types anymore.

It might be possible to avoid the breakage by doing more trait magic to
still allow non tupled types in those places. They would implicitly be
treated as a tuple of a single element. I feel in the long term this is
more confusing as users would have to remember the special case instead
of always tupling. For example, a function taking a solidity bool would
be callable with a rust bool or (bool,) but a function taking a (bool,)
would only be callable with ((bool,),).

Note that the current release of ethabi does no handle abi v2 but there
are PRs and forks that do which ethabi will hopefully integrate.

---

Edit:
For the function return type we could do something smarter so that the tuple for single types isn't needed because function return types do not have the ambiguity as they are always a single token. This would be something we assert on top of ethabi where Function::Output is `Vec<Param>` instead of just Param for some reason. Or can abi have several output tokens against my expectation? (edit: looks like when returning a tuple older versions of solc would output a list of types instead of a single tuple type) The implementation would be as easy as using Tokenizable instead of Detokenize for the return type.