### PR TITLE
add http-rustls feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -122,6 +122,12 @@ jobs:
           command:                 check
           toolchain:               stable
           args:                    --no-default-features --features http-tls
+      - name:                      Checking http-rustls
+        uses:                      actions-rs/cargo@master
+        with:
+          command:                 check
+          toolchain:               stable
+          args:                    --no-default-features --features http-rustls
       - name:                      Checking ws-tokio
         uses:                      actions-rs/cargo@master
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,8 @@ pin-project = "1.0"
 base64 = { version = "0.13", optional = true }
 hyper = { version = "0.14", optional = true, default-features = false, features = ["client", "http1", "stream", "tcp"] }
 hyper-tls = { version = "0.5", optional = true }
-hyper-proxy = { version = "0.9.0", optional = true }
+hyper-proxy = {version = "0.9.0", default-features = false, optional = true }
+hyper-rustls = { version = "0.22.1", default-features = false, features = ["webpki-tokio"], optional = true }
 headers = { version = "0.3", optional = true }
 ## WS
 async-native-tls = { git = "https://github.com/async-email/async-native-tls.git", rev = "b5b5562d6cea77f913d4cbe448058c031833bf17", optional = true, default-features = false }
@@ -66,8 +67,10 @@ tokio-stream = { version = "0.1", features = ["net"] }
 [features]
 default = ["http-tls", "signing", "ws-tls-tokio", "ipc-tokio"]
 eip-1193 = ["js-sys", "wasm-bindgen", "wasm-bindgen-futures", "futures-timer/wasm-bindgen", "rand", "getrandom"]
-http = ["hyper", "hyper-proxy", "url", "base64", "headers"]
+_http_base = ["hyper", "url", "base64", "headers"]
+http = ["_http_base", "hyper-proxy/tls"]
 http-tls = ["hyper-tls", "http"]
+http-rustls = ["hyper-rustls", "_http_base", "hyper-proxy/rustls-webpki"]
 signing = ["secp256k1"]
 ws-tokio = ["soketto", "url", "tokio", "tokio-util"]
 ws-async-std = ["soketto", "url", "async-std"]

--- a/README.md
+++ b/README.md
@@ -113,11 +113,20 @@ To compile, you need to disable the IPC feature:
 web3 = { version = "0.14.0", default-features = false, features = ["http"] }
 ```
 
+# Avoiding OpenSSL dependency
+
+On Linux, `native-tls` is implemented using OpenSSL. To avoid that dependency
+for HTTPS use the corresponding feature.
+```
+web3 = { version = "0.14.0", default-features = false, features = ["http-rustls"] }
+```
+
 # Cargo Features
 
 The library supports following features:
 - `http` - Enables `http` transport.
-- `http-tls` - Enables `http` over TLS (`https`) transport support. Implies `http`.
+- `http-tls` - Enables `http` over TLS (`https`) transport support using OS-native TLS. Implies `http`.
+- `http-rustls` - Enables `http` over TLS (`https`) transport support using rustls. Implies `http`.
 - `ipc-tokio` - Enables `ipc` transport (`tokio` runtime). *NIX only!
 - `ws-tokio` - Enables `ws` tranport (`tokio` runtime).
 - `ws-tls-tokio` - Enables `wss` tranport (`tokio` runtime).


### PR DESCRIPTION
The existing `http-tls` feature enables TLS support via `hyper-tls` which in turn pulls in OpenSSL on Linux via `native-tls`. OpenSSL is written in C and has a long history of vulnerabilities caused by memory corruption.

The new `http-rustls` feature allows to choose a TLS implementation that is written in Rust.

Depends on #454 being merged first. I'll rebase once that happens.