### PR TITLE
Export http module also for http-rustls

### DIFF
--- a/src/transports/mod.rs
+++ b/src/transports/mod.rs
@@ -5,9 +5,9 @@ pub use self::batch::Batch;
 pub mod either;
 pub use self::either::Either;
 
-#[cfg(feature = "http")]
+#[cfg(any(feature = "http", feature = "http-rustls"))]
 pub mod http;
-#[cfg(feature = "http")]
+#[cfg(any(feature = "http", feature = "http-rustls"))]
 pub use self::http::Http;
 
 #[cfg(any(feature = "ws-tokio", feature = "ws-async-std"))]


### PR DESCRIPTION
This slipped through when the `_http_base` "private" feature was factored out. `http-tls` implicitly selects `http` and is already covered by the `cfg` condition.