### PR TITLE
Adding eth_getProof eth_ JSON-RPC method

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -7,6 +7,7 @@ mod fee_history;
 mod log;
 mod parity_peers;
 mod parity_pending_transaction;
+mod proof;
 mod recovery;
 mod signed;
 mod sync_state;
@@ -31,6 +32,7 @@ pub use self::{
     parity_pending_transaction::{
         FilterCondition, ParityPendingTransactionFilter, ParityPendingTransactionFilterBuilder, ToFilter,
     },
+    proof::Proof,
     recovery::{Recovery, RecoveryMessage},
     signed::{SignedData, SignedTransaction, TransactionParameters},
     sync_state::{SyncInfo, SyncState},

--- a/src/types/proof.rs
+++ b/src/types/proof.rs
@@ -1,0 +1,37 @@
+use crate::types::Bytes;
+use ethereum_types::{H256, U256, U64};
+use serde::{Deserialize, Serialize};
+
+///Proof struct returned by eth_getProof method
+///
+/// https://eips.ethereum.org/EIPS/eip-1186
+#[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
+pub struct Proof {
+    /// the balance of the account. See eth_getBalance
+    pub balance: U64,
+    ///  hash of the code of the account
+    #[serde(rename = "codeHash")]
+    pub code_hash: H256,
+    /// nonce of the account. See eth_getTransactionCount
+    pub nonce: U64,
+    /// SHA3 of the StorageRoot.
+    #[serde(rename = "storageHash")]
+    pub storage_hash: H256,
+    /// Array of rlp-serialized MerkleTree-Nodes, starting with the stateRoot-Node, following the path of the SHA3 (address) as key.
+    #[serde(rename = "accountProof")]
+    pub account_proof: Vec<Bytes>,
+    /// Array of storage-entries as requested
+    #[serde(rename = "storageProof")]
+    pub storage_proof: Vec<StorageProof>,
+}
+
+/// A key-value pair and it's state proof.
+#[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize)]
+pub struct StorageProof {
+    /// the requested storage key
+    pub key: U256,
+    /// the storage value
+    pub value: U256,
+    /// Array of rlp-serialized MerkleTree-Nodes, starting with the storageHash-Node, following the path of the SHA3 (key) as path.
+    pub proof: Vec<Bytes>,
+}


### PR DESCRIPTION
Described in EIP-1186 [1], it is not a very well documented method,
its description is missing from many resources [2], [3], however
it is present in the current ethereum client implementation [4].

This commit adds the necesarry struct and method to add this method.

[1] https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1186.md
[2] https://eth.wiki/json-rpc/API
[3] https://github.com/ethereum/execution-apis
[4] https://github.com/ethereum/go-ethereum/blob/master/internal/web3ext/web3ext.go#L561