### PR TITLE
Report HTTP failure codes as RPC errors if returned for an RPC call

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,17 @@ use std::io::Error as IoError;
 /// Web3 `Result` type.
 pub type Result<T = ()> = std::result::Result<T, Error>;
 
+/// Transport-depended error.
+#[derive(Display, Debug, Clone, PartialEq)]
+pub enum TransportError {
+    /// Transport-specific error code.
+    #[display(fmt = "code {}", _0)]
+    Code(u16),
+    /// Arbitrary, developer-readable description of the occurred error.
+    #[display(fmt = "{}", _0)]
+    Message(String),
+}
+
 /// Errors which can occur when attempting to generate resource uri.
 #[derive(Debug, Display, From)]
 pub enum Error {
@@ -21,9 +32,9 @@ pub enum Error {
     #[from(ignore)]
     InvalidResponse(String),
     /// transport error
-    #[display(fmt = "Transport error: {}", _0)]
+    #[display(fmt = "Transport error: {}" _0)]
     #[from(ignore)]
-    Transport(String),
+    Transport(TransportError),
     /// rpc error
     #[display(fmt = "RPC error: {:?}", _0)]
     Rpc(RPCError),
@@ -42,7 +53,7 @@ impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;
         match *self {
-            Unreachable | Decoder(_) | InvalidResponse(_) | Transport(_) | Internal => None,
+            Unreachable | Decoder(_) | InvalidResponse(_) | Transport { .. } | Internal => None,
             Rpc(ref e) => Some(e),
             Io(ref e) => Some(e),
             Recovery(ref e) => Some(e),
@@ -78,9 +89,8 @@ impl PartialEq for Error {
         use self::Error::*;
         match (self, other) {
             (Unreachable, Unreachable) | (Internal, Internal) => true,
-            (Decoder(a), Decoder(b)) | (InvalidResponse(a), InvalidResponse(b)) | (Transport(a), Transport(b)) => {
-                a == b
-            }
+            (Decoder(a), Decoder(b)) | (InvalidResponse(a), InvalidResponse(b)) => a == b,
+            (Transport(a), Transport(b)) => a == b,
             (Rpc(a), Rpc(b)) => a == b,
             (Io(a), Io(b)) => a.kind() == b.kind(),
             (Recovery(a), Recovery(b)) => a == b,

--- a/src/transports/ipc.rs
+++ b/src/transports/ipc.rs
@@ -1,6 +1,9 @@
 //! IPC transport
 
-use crate::{api::SubscriptionId, helpers, BatchTransport, DuplexTransport, Error, RequestId, Result, Transport};
+use crate::{
+    api::SubscriptionId, error::TransportError, helpers, BatchTransport, DuplexTransport, Error, RequestId, Result,
+    Transport,
+};
 use futures::{
     future::{join_all, JoinAll},
     stream::StreamExt,
@@ -324,13 +327,13 @@ fn respond_output(
 
 impl From<mpsc::error::SendError<TransportMessage>> for Error {
     fn from(err: mpsc::error::SendError<TransportMessage>) -> Self {
-        Error::Transport(format!("Send Error: {:?}", err))
+        Error::Transport(TransportError::Message(format!("Send Error: {:?}", err)))
     }
 }
 
 impl From<oneshot::error::RecvError> for Error {
     fn from(err: oneshot::error::RecvError) -> Self {
-        Error::Transport(format!("Recv Error: {:?}", err))
+        Error::Transport(TransportError::Message(format!("Recv Error: {:?}", err)))
     }
 }
 

--- a/src/transports/mod.rs
+++ b/src/transports/mod.rs
@@ -1,7 +1,6 @@
 //! Supported Ethereum JSON-RPC transports.
 
 pub mod batch;
-use crate::error::TransportError;
 
 pub use self::batch::Batch;
 pub mod either;
@@ -28,6 +27,7 @@ pub mod test;
 #[cfg(feature = "url")]
 impl From<url::ParseError> for crate::Error {
     fn from(err: url::ParseError) -> Self {
+        use crate::error::TransportError;
         crate::Error::Transport(TransportError::Message(format!("failed to parse url: {}", err)))
     }
 }
@@ -35,6 +35,7 @@ impl From<url::ParseError> for crate::Error {
 #[cfg(feature = "async-native-tls")]
 impl From<async_native_tls::Error> for crate::Error {
     fn from(err: async_native_tls::Error) -> Self {
+        use crate::error::TransportError;
         crate::Error::Transport(TransportError::Message(format!("{:?}", err)))
     }
 }

--- a/src/transports/mod.rs
+++ b/src/transports/mod.rs
@@ -1,6 +1,8 @@
 //! Supported Ethereum JSON-RPC transports.
 
 pub mod batch;
+use crate::error::TransportError;
+
 pub use self::batch::Batch;
 pub mod either;
 pub use self::either::Either;
@@ -26,14 +28,14 @@ pub mod test;
 #[cfg(feature = "url")]
 impl From<url::ParseError> for crate::Error {
     fn from(err: url::ParseError) -> Self {
-        crate::Error::Transport(format!("failed to parse url: {}", err))
+        crate::Error::Transport(TransportError::Message(format!("failed to parse url: {}", err)))
     }
 }
 
 #[cfg(feature = "async-native-tls")]
 impl From<async_native_tls::Error> for crate::Error {
     fn from(err: async_native_tls::Error) -> Self {
-        crate::Error::Transport(format!("{:?}", err))
+        crate::Error::Transport(TransportError::Message(format!("{:?}", err)))
     }
 }
 

--- a/src/transports/ws.rs
+++ b/src/transports/ws.rs
@@ -1,7 +1,11 @@
 //! WebSocket Transport
 
 use self::compat::{TcpStream, TlsStream};
-use crate::{api::SubscriptionId, error, helpers, rpc, BatchTransport, DuplexTransport, Error, RequestId, Transport};
+use crate::{
+    api::SubscriptionId,
+    error::{self, TransportError},
+    helpers, rpc, BatchTransport, DuplexTransport, Error, RequestId, Transport,
+};
 use futures::{
     channel::{mpsc, oneshot},
     task::{Context, Poll},
@@ -22,13 +26,13 @@ use url::Url;
 
 impl From<soketto::handshake::Error> for Error {
     fn from(err: soketto::handshake::Error) -> Self {
-        Error::Transport(format!("Handshake Error: {:?}", err))
+        Error::Transport(TransportError::Message(format!("Handshake Error: {:?}", err)))
     }
 }
 
 impl From<connection::Error> for Error {
     fn from(err: connection::Error) -> Self {
-        Error::Transport(format!("Connection Error: {:?}", err))
+        Error::Transport(TransportError::Message(format!("Connection Error: {:?}", err)))
     }
 }
 
@@ -100,12 +104,21 @@ impl WsServerTask {
 
         let scheme = match url.scheme() {
             s if s == "ws" || s == "wss" => s,
-            s => return Err(error::Error::Transport(format!("Wrong scheme: {}", s))),
+            s => {
+                return Err(error::Error::Transport(TransportError::Message(format!(
+                    "Wrong scheme: {}",
+                    s
+                ))))
+            }
         };
 
         let host = match url.host_str() {
             Some(s) => s,
-            None => return Err(error::Error::Transport("Wrong host name".to_string())),
+            None => {
+                return Err(error::Error::Transport(TransportError::Message(
+                    "Wrong host name".to_string(),
+                )))
+            }
         };
 
         let port = url.port().unwrap_or(if scheme == "ws" { 80 } else { 443 });
@@ -143,16 +156,10 @@ impl WsServerTask {
         let (sender, receiver) = match handshake.await? {
             ServerResponse::Accepted { .. } => client.into_builder().finish(),
             ServerResponse::Redirect { status_code, location } => {
-                return Err(error::Error::Transport(format!(
-                    "(code: {}) Unable to follow redirects: {}",
-                    status_code, location
-                )))
+                return Err(error::Error::Transport(TransportError::Code(status_code)))
             }
             ServerResponse::Rejected { status_code } => {
-                return Err(error::Error::Transport(format!(
-                    "(code: {}) Connection rejected.",
-                    status_code
-                )))
+                return Err(error::Error::Transport(TransportError::Code(status_code)))
             }
         };
 
@@ -342,7 +349,9 @@ impl WebSocket {
 }
 
 fn dropped_err<T>(_: T) -> error::Error {
-    Error::Transport("Cannot send request. Internal task finished.".into())
+    Error::Transport(TransportError::Message(
+        "Cannot send request. Internal task finished.".into(),
+    ))
 }
 
 fn batch_to_single(response: BatchResult) -> SingleResult {

--- a/src/transports/ws.rs
+++ b/src/transports/ws.rs
@@ -155,7 +155,7 @@ impl WsServerTask {
         let handshake = client.handshake();
         let (sender, receiver) = match handshake.await? {
             ServerResponse::Accepted { .. } => client.into_builder().finish(),
-            ServerResponse::Redirect { status_code, ... } => {
+            ServerResponse::Redirect { status_code, .. } => {
                 return Err(error::Error::Transport(TransportError::Code(status_code)))
             }
             ServerResponse::Rejected { status_code } => {

--- a/src/transports/ws.rs
+++ b/src/transports/ws.rs
@@ -155,7 +155,7 @@ impl WsServerTask {
         let handshake = client.handshake();
         let (sender, receiver) = match handshake.await? {
             ServerResponse::Accepted { .. } => client.into_builder().finish(),
-            ServerResponse::Redirect { status_code, location } => {
+            ServerResponse::Redirect { status_code, ... } => {
                 return Err(error::Error::Transport(TransportError::Code(status_code)))
             }
             ServerResponse::Rejected { status_code } => {


### PR DESCRIPTION
At least in the Alchemy JSON RPC API over HTTP, rate limit errors are returned as HTTP 429. Currently these errors are converted to Error::Transport(String) and it's not possible to cleanly access the status code. Moreover, `Error::Transport` also means errors like failure to deserialize, whose handling will be completely different than handling of capacity limits or rate limit.

This PR changes representations of the errors returned in `execute_rpc` to `rpc::error::Error`. Since the HTTP error codes aren't any of the variants defined by jsonrpc-core, the error code will be `ErrorCode::ServerError(i64)`.

cf. https://docs.alchemy.com/alchemy/documentation/error-reference