### PR TITLE
move Accounts::hash_message and make it static

### DIFF
--- a/src/api/accounts.rs
+++ b/src/api/accounts.rs
@@ -1,7 +1,7 @@
 //! Partial implementation of the `Accounts` namespace.
 
 use crate::{
-    api::{hash_message, Namespace},
+    api::Namespace,
     signing,
     types::{AccessList, H256, U64},
     Transport,
@@ -36,7 +36,7 @@ impl<T: Transport> Accounts<T> {
     where
         S: AsRef<[u8]>,
     {
-        hash_message(message)
+        signing::hash_message(message)
     }
 }
 

--- a/src/api/accounts.rs
+++ b/src/api/accounts.rs
@@ -1,7 +1,7 @@
 //! Partial implementation of the `Accounts` namespace.
 
 use crate::{
-    api::Namespace,
+    api::{hash_message, Namespace},
     signing,
     types::{AccessList, H256, U64},
     Transport,
@@ -36,12 +36,7 @@ impl<T: Transport> Accounts<T> {
     where
         S: AsRef<[u8]>,
     {
-        let message = message.as_ref();
-
-        let mut eth_message = format!("\x19Ethereum Signed Message:\n{}", message.len()).into_bytes();
-        eth_message.extend_from_slice(message);
-
-        signing::keccak256(&eth_message).into()
+        hash_message(message)
     }
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -29,8 +29,8 @@ pub use self::{
 };
 
 use crate::{
-    confirm, error, signing,
-    types::{Bytes, TransactionReceipt, TransactionRequest, H256, U64},
+    confirm, error,
+    types::{Bytes, TransactionReceipt, TransactionRequest, U64},
     DuplexTransport, Transport,
 };
 use futures::Future;
@@ -162,21 +162,4 @@ impl<T: DuplexTransport> Web3<T> {
     pub fn eth_subscribe(&self) -> eth_subscribe::EthSubscribe<T> {
         self.api()
     }
-}
-
-/// Hash a message according to EIP-191.
-///
-/// The data is a UTF-8 encoded string and will enveloped as follows:
-/// `"\x19Ethereum Signed Message:\n" + message.length + message` and hashed
-/// using keccak256.
-pub fn hash_message<S>(message: S) -> H256
-where
-    S: AsRef<[u8]>,
-{
-    let message = message.as_ref();
-
-    let mut eth_message = format!("\x19Ethereum Signed Message:\n{}", message.len()).into_bytes();
-    eth_message.extend_from_slice(message);
-
-    signing::keccak256(&eth_message).into()
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -30,7 +30,7 @@ pub use self::{
 
 use crate::{
     confirm, error, signing,
-    types::{Bytes, TransactionReceipt, TransactionRequest, U64, H256},
+    types::{Bytes, TransactionReceipt, TransactionRequest, H256, U64},
     DuplexTransport, Transport,
 };
 use futures::Future;
@@ -170,8 +170,8 @@ impl<T: DuplexTransport> Web3<T> {
 /// `"\x19Ethereum Signed Message:\n" + message.length + message` and hashed
 /// using keccak256.
 pub fn hash_message<S>(message: S) -> H256
-    where
-        S: AsRef<[u8]>,
+where
+    S: AsRef<[u8]>,
 {
     let message = message.as_ref();
 

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -218,6 +218,23 @@ pub fn namehash(name: &str) -> NameHash {
     node
 }
 
+/// Hash a message according to EIP-191.
+///
+/// The data is a UTF-8 encoded string and will enveloped as follows:
+/// `"\x19Ethereum Signed Message:\n" + message.length + message` and hashed
+/// using keccak256.
+pub fn hash_message<S>(message: S) -> H256
+where
+    S: AsRef<[u8]>,
+{
+    let message = message.as_ref();
+
+    let mut eth_message = format!("\x19Ethereum Signed Message:\n{}", message.len()).into_bytes();
+    eth_message.extend_from_slice(message);
+
+    keccak256(&eth_message).into()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Account::hash_message is actually a static function, there's no point in having it under Accounts. It would be more convenient to be able to access this function without creating an Account and a Transport. I've kept the Accounts::hash_message function for backward compatibility reasons though.
I've moved hash_message to api/mod.rs as I haven't found a better place for it, but I'm open to suggestions. Is there already place for static functions like this under api somewhere?

Let me know if I need to do anything else, because this is my first contribution for this project!