### PR TITLE
Allow setting basic auth credentials in websocket url

### DIFF
--- a/src/transports/ws.rs
+++ b/src/transports/ws.rs
@@ -139,6 +139,20 @@ impl WsServerTask {
             resource
         );
         let mut client = Client::new(socket, host, &resource);
+        let maybe_encoded = url.password().map(|password| {
+            use headers::authorization::{Authorization, Credentials};
+            log::trace!("Basic auth username: {}", url.username());
+            log::trace!("Basic auth password: {}", password);
+            Authorization::basic(url.username(), password).0.encode().to_str().unwrap().as_bytes().to_owned()
+        });
+
+        let headers = if let Some(ref head) = maybe_encoded {
+            Some([soketto::handshake::client::Header {name: "Authorization",value: &head }])
+        } else { None };
+
+        if let Some(ref head) = headers {
+            client.set_headers(head);
+        }
         let handshake = client.handshake();
         let (sender, receiver) = match handshake.await? {
             ServerResponse::Accepted { .. } => client.into_builder().finish(),

--- a/src/transports/ws.rs
+++ b/src/transports/ws.rs
@@ -141,8 +141,6 @@ impl WsServerTask {
         let mut client = Client::new(socket, host, &resource);
         let maybe_encoded = url.password().map(|password| {
             use headers::authorization::{Authorization, Credentials};
-            log::trace!("Basic auth username: {}", url.username());
-            log::trace!("Basic auth password: {}", password);
             Authorization::basic(url.username(), password).0.encode().to_str().unwrap().as_bytes().to_owned()
         });
 

--- a/src/transports/ws.rs
+++ b/src/transports/ws.rs
@@ -145,7 +145,7 @@ impl WsServerTask {
         });
 
         let headers = if let Some(ref head) = maybe_encoded {
-            Some([soketto::handshake::client::Header {name: "Authorization",value: &head }])
+            Some([soketto::handshake::client::Header {name: "Authorization", value: &head }])
         } else { None };
 
         if let Some(ref head) = headers {

--- a/src/transports/ws.rs
+++ b/src/transports/ws.rs
@@ -141,7 +141,7 @@ impl WsServerTask {
         let mut client = Client::new(socket, host, &resource);
         let maybe_encoded = url.password().map(|password| {
             use headers::authorization::{Authorization, Credentials};
-            Authorization::basic(url.username(), password).0.encode().to_str().unwrap().as_bytes().to_owned()
+            Authorization::basic(url.username(), password).0.encode().as_bytes().to_vec()
         });
 
         let headers = if let Some(ref head) = maybe_encoded {

--- a/src/transports/ws.rs
+++ b/src/transports/ws.rs
@@ -141,12 +141,21 @@ impl WsServerTask {
         let mut client = Client::new(socket, host, &resource);
         let maybe_encoded = url.password().map(|password| {
             use headers::authorization::{Authorization, Credentials};
-            Authorization::basic(url.username(), password).0.encode().as_bytes().to_vec()
+            Authorization::basic(url.username(), password)
+                .0
+                .encode()
+                .as_bytes()
+                .to_vec()
         });
 
         let headers = if let Some(ref head) = maybe_encoded {
-            Some([soketto::handshake::client::Header {name: "Authorization", value: &head }])
-        } else { None };
+            Some([soketto::handshake::client::Header {
+                name: "Authorization",
+                value: &head,
+            }])
+        } else {
+            None
+        };
 
         if let Some(ref head) = headers {
             client.set_headers(head);


### PR DESCRIPTION
These could be set before, but would be ignored by soketto. Now they're propagated to the backend.