### PR TITLE
Expose `ParseSignatureError` from `recovery` module

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -33,7 +33,7 @@ pub use self::{
         FilterCondition, ParityPendingTransactionFilter, ParityPendingTransactionFilterBuilder, ToFilter,
     },
     proof::Proof,
-    recovery::{Recovery, RecoveryMessage},
+    recovery::{Recovery, RecoveryMessage, ParseSignatureError},
     signed::{SignedData, SignedTransaction, TransactionParameters},
     sync_state::{SyncInfo, SyncState},
     trace_filtering::{

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -33,7 +33,7 @@ pub use self::{
         FilterCondition, ParityPendingTransactionFilter, ParityPendingTransactionFilterBuilder, ToFilter,
     },
     proof::Proof,
-    recovery::{Recovery, RecoveryMessage, ParseSignatureError},
+    recovery::{ParseSignatureError, Recovery, RecoveryMessage},
     signed::{SignedData, SignedTransaction, TransactionParameters},
     sync_state::{SyncInfo, SyncState},
     trace_filtering::{


### PR DESCRIPTION
Fixes https://github.com/tomusdrw/rust-web3/issues/536