### PR TITLE
Make fields optional when deserializing for compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,5 +84,6 @@ ws-tls-async-std = ["async-native-tls", "async-native-tls/runtime-async-std", "w
 ipc-tokio = ["tokio", "tokio-stream", "tokio-util"]
 arbitrary_precision = ["serde_json/arbitrary_precision", "jsonrpc-core/arbitrary_precision"]
 test = []
+allow-missing-fields = []
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -131,3 +131,6 @@ The library supports following features:
 - `eip-1193` - Enable EIP-1193 support.
 - `wasm` - Compile for WASM (make sure to disable default features).
 - `arbitrary_precision` - Enable `arbitrary_precision` in `serde_json`.
+- `allow-missing-fields` - Some response fields are mandatory in Ethereum but not present in
+  EVM-compatible chains such as Celo and Fantom. This feature enables compatibility by setting a
+  default value on those fields.

--- a/src/types/block.rs
+++ b/src/types/block.rs
@@ -11,7 +11,7 @@ pub struct BlockHeader {
     pub parent_hash: H256,
     /// Hash of the uncles
     #[serde(rename = "sha3Uncles")]
-    #[serde(default)] // Celo doesn't have this field.
+    #[serde(default)]
     pub uncles_hash: H256,
     /// Miner/author's address.
     #[serde(rename = "miner", default, deserialize_with = "null_to_default")]
@@ -32,7 +32,7 @@ pub struct BlockHeader {
     pub gas_used: U256,
     /// Gas Limit
     #[serde(rename = "gasLimit")]
-    #[serde(default)] // Celo doesn't have this field.
+    #[serde(default)]
     pub gas_limit: U256,
     /// Base fee per unit of gas (if past London)
     #[serde(rename = "baseFeePerGas", skip_serializing_if = "Option::is_none")]
@@ -46,7 +46,7 @@ pub struct BlockHeader {
     /// Timestamp
     pub timestamp: U256,
     /// Difficulty
-    #[serde(default)] // Celo doesn't have this field.
+    #[serde(default)]
     pub difficulty: U256,
     /// Mix Hash
     #[serde(rename = "mixHash")]
@@ -66,7 +66,7 @@ pub struct Block<TX> {
     pub parent_hash: H256,
     /// Hash of the uncles
     #[serde(rename = "sha3Uncles")]
-    #[serde(default)] // Celo doesn't have this field.
+    #[serde(default)]
     pub uncles_hash: H256,
     /// Miner/author's address.
     #[serde(rename = "miner", default, deserialize_with = "null_to_default")]
@@ -87,7 +87,7 @@ pub struct Block<TX> {
     pub gas_used: U256,
     /// Gas Limit
     #[serde(rename = "gasLimit")]
-    #[serde(default)] // Celo doesn't have this field.
+    #[serde(default)]
     pub gas_limit: U256,
     /// Base fee per unit of gas (if past London)
     #[serde(rename = "baseFeePerGas", skip_serializing_if = "Option::is_none")]
@@ -101,7 +101,7 @@ pub struct Block<TX> {
     /// Timestamp
     pub timestamp: U256,
     /// Difficulty
-    #[serde(default)] // Celo doesn't have this field.
+    #[serde(default)]
     pub difficulty: U256,
     /// Total difficulty
     #[serde(rename = "totalDifficulty")]
@@ -110,7 +110,7 @@ pub struct Block<TX> {
     #[serde(default, rename = "sealFields")]
     pub seal_fields: Vec<Bytes>,
     /// Uncles' hashes
-    #[serde(default)] // Celo doesn't have this field.
+    #[serde(default)]
     pub uncles: Vec<H256>,
     /// Transactions
     pub transactions: Vec<TX>,

--- a/src/types/block.rs
+++ b/src/types/block.rs
@@ -11,7 +11,7 @@ pub struct BlockHeader {
     pub parent_hash: H256,
     /// Hash of the uncles
     #[serde(rename = "sha3Uncles")]
-    #[serde(default)]
+    #[cfg_attr(feature = "allow-missing-fields", serde(default))]
     pub uncles_hash: H256,
     /// Miner/author's address.
     #[serde(rename = "miner", default, deserialize_with = "null_to_default")]
@@ -32,7 +32,7 @@ pub struct BlockHeader {
     pub gas_used: U256,
     /// Gas Limit
     #[serde(rename = "gasLimit")]
-    #[serde(default)]
+    #[cfg_attr(feature = "allow-missing-fields", serde(default))]
     pub gas_limit: U256,
     /// Base fee per unit of gas (if past London)
     #[serde(rename = "baseFeePerGas", skip_serializing_if = "Option::is_none")]
@@ -46,7 +46,7 @@ pub struct BlockHeader {
     /// Timestamp
     pub timestamp: U256,
     /// Difficulty
-    #[serde(default)]
+    #[cfg_attr(feature = "allow-missing-fields", serde(default))]
     pub difficulty: U256,
     /// Mix Hash
     #[serde(rename = "mixHash")]
@@ -66,7 +66,7 @@ pub struct Block<TX> {
     pub parent_hash: H256,
     /// Hash of the uncles
     #[serde(rename = "sha3Uncles")]
-    #[serde(default)]
+    #[cfg_attr(feature = "allow-missing-fields", serde(default))]
     pub uncles_hash: H256,
     /// Miner/author's address.
     #[serde(rename = "miner", default, deserialize_with = "null_to_default")]
@@ -87,7 +87,7 @@ pub struct Block<TX> {
     pub gas_used: U256,
     /// Gas Limit
     #[serde(rename = "gasLimit")]
-    #[serde(default)]
+    #[cfg_attr(feature = "allow-missing-fields", serde(default))]
     pub gas_limit: U256,
     /// Base fee per unit of gas (if past London)
     #[serde(rename = "baseFeePerGas", skip_serializing_if = "Option::is_none")]
@@ -101,7 +101,7 @@ pub struct Block<TX> {
     /// Timestamp
     pub timestamp: U256,
     /// Difficulty
-    #[serde(default)]
+    #[cfg_attr(feature = "allow-missing-fields", serde(default))]
     pub difficulty: U256,
     /// Total difficulty
     #[serde(rename = "totalDifficulty")]
@@ -110,7 +110,7 @@ pub struct Block<TX> {
     #[serde(default, rename = "sealFields")]
     pub seal_fields: Vec<Bytes>,
     /// Uncles' hashes
-    #[serde(default)]
+    #[cfg_attr(feature = "allow-missing-fields", serde(default))]
     pub uncles: Vec<H256>,
     /// Transactions
     pub transactions: Vec<TX>,

--- a/src/types/block.rs
+++ b/src/types/block.rs
@@ -11,6 +11,7 @@ pub struct BlockHeader {
     pub parent_hash: H256,
     /// Hash of the uncles
     #[serde(rename = "sha3Uncles")]
+    #[serde(default)] // Celo doesn't have this field.
     pub uncles_hash: H256,
     /// Miner/author's address.
     #[serde(rename = "miner", default, deserialize_with = "null_to_default")]
@@ -31,6 +32,7 @@ pub struct BlockHeader {
     pub gas_used: U256,
     /// Gas Limit
     #[serde(rename = "gasLimit")]
+    #[serde(default)] // Celo doesn't have this field.
     pub gas_limit: U256,
     /// Base fee per unit of gas (if past London)
     #[serde(rename = "baseFeePerGas", skip_serializing_if = "Option::is_none")]
@@ -44,6 +46,7 @@ pub struct BlockHeader {
     /// Timestamp
     pub timestamp: U256,
     /// Difficulty
+    #[serde(default)] // Celo doesn't have this field.
     pub difficulty: U256,
     /// Mix Hash
     #[serde(rename = "mixHash")]
@@ -63,6 +66,7 @@ pub struct Block<TX> {
     pub parent_hash: H256,
     /// Hash of the uncles
     #[serde(rename = "sha3Uncles")]
+    #[serde(default)] // Celo doesn't have this field.
     pub uncles_hash: H256,
     /// Miner/author's address.
     #[serde(rename = "miner", default, deserialize_with = "null_to_default")]
@@ -83,6 +87,7 @@ pub struct Block<TX> {
     pub gas_used: U256,
     /// Gas Limit
     #[serde(rename = "gasLimit")]
+    #[serde(default)] // Celo doesn't have this field.
     pub gas_limit: U256,
     /// Base fee per unit of gas (if past London)
     #[serde(rename = "baseFeePerGas", skip_serializing_if = "Option::is_none")]
@@ -96,6 +101,7 @@ pub struct Block<TX> {
     /// Timestamp
     pub timestamp: U256,
     /// Difficulty
+    #[serde(default)] // Celo doesn't have this field.
     pub difficulty: U256,
     /// Total difficulty
     #[serde(rename = "totalDifficulty")]
@@ -104,6 +110,7 @@ pub struct Block<TX> {
     #[serde(default, rename = "sealFields")]
     pub seal_fields: Vec<Bytes>,
     /// Uncles' hashes
+    #[serde(default)] // Celo doesn't have this field.
     pub uncles: Vec<H256>,
     /// Transactions
     pub transactions: Vec<TX>,

--- a/src/types/trace_filtering.rs
+++ b/src/types/trace_filtering.rs
@@ -160,7 +160,7 @@ pub struct CallResult {
     #[serde(rename = "gasUsed")]
     pub gas_used: U256,
     /// Output bytes
-    #[serde(default)]
+    #[cfg_attr(feature = "allow-missing-fields", serde(default))]
     pub output: Bytes,
 }
 
@@ -188,7 +188,7 @@ pub struct Call {
     /// Gas
     pub gas: U256,
     /// Input data
-    #[serde(default)]
+    #[cfg_attr(feature = "allow-missing-fields", serde(default))]
     pub input: Bytes,
     /// The type of the call.
     #[serde(rename = "callType")]

--- a/src/types/trace_filtering.rs
+++ b/src/types/trace_filtering.rs
@@ -187,6 +187,7 @@ pub struct Call {
     /// Gas
     pub gas: U256,
     /// Input data
+    #[serde(default)]
     pub input: Bytes,
     /// The type of the call.
     #[serde(rename = "callType")]

--- a/src/types/trace_filtering.rs
+++ b/src/types/trace_filtering.rs
@@ -160,6 +160,7 @@ pub struct CallResult {
     #[serde(rename = "gasUsed")]
     pub gas_used: U256,
     /// Output bytes
+    #[serde(default)]
     pub output: Bytes,
 }
 


### PR DESCRIPTION
This changes are necessary for compatibility with some EVM-compatible chains such as Celo and Fantom. I hope you're willing to take this small patch to support these chains.