### PR TITLE
add ws reconnection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 Cargo.lock
 *.swp
 .idea/
+db

--- a/examples/contract_log_filter_loss_connection.rs
+++ b/examples/contract_log_filter_loss_connection.rs
@@ -1,0 +1,85 @@
+use std::time::Duration;
+
+use ethabi::Address;
+use futures::{future, TryStreamExt};
+use hex_literal::hex;
+use web3::{
+    api::BaseFilter,
+    contract::{Contract, Options},
+    transports::WebSocket,
+    types::{Filter, FilterBuilder, Log},
+    Web3,
+};
+
+#[tokio::main]
+async fn main() -> web3::contract::Result<()> {
+    let _ = env_logger::try_init();
+    let transport = web3::transports::WebSocket::new("ws://localhost:8545").await?;
+    let web3 = web3::Web3::new(transport);
+
+    println!("Calling accounts.");
+    let accounts = web3.eth().accounts().await?;
+
+    let bytecode = include_str!("./res/SimpleEvent.bin");
+    let contract = Contract::deploy(web3.eth(), include_bytes!("./res/SimpleEvent.abi"))?
+        .confirmations(1)
+        .poll_interval(Duration::from_secs(10))
+        .options(Options::with(|opt| opt.gas = Some(3_000_000u64.into())))
+        .execute(bytecode, (), accounts[0])
+        .await
+        .unwrap();
+
+    println!("contract deployed at: {}", contract.address());
+
+    tokio::spawn(interval_contract_call(contract.clone(), accounts[0]));
+
+    // Filter for Hello event in our contract
+    let filter = FilterBuilder::default()
+        .address(vec![contract.address()])
+        .topics(
+            Some(vec![hex!(
+                "d282f389399565f3671145f5916e51652b60eee8e5c759293a2f5771b8ddfd2e"
+            )
+            .into()]),
+            None,
+            None,
+            None,
+        )
+        .build();
+
+    loop {
+        let filter = get_filter(web3.clone(), &filter).await;
+        let logs_stream = filter.stream(Duration::from_secs(2));
+        let res = logs_stream
+            .try_for_each(|log| {
+                println!("Get log: {:?}", log);
+                future::ready(Ok(()))
+            })
+            .await;
+
+        if let Err(e) = res {
+            println!("Log Filter Error: {}", e);
+        }
+    }
+}
+
+async fn interval_contract_call(contract: Contract<WebSocket>, account: Address) {
+    loop {
+        match contract.call("hello", (), account, Options::default()).await {
+            Ok(tx) => println!("got tx: {:?}", tx),
+            Err(e) => println!("get tx failed: {}", e),
+        }
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+pub async fn get_filter(web3: Web3<WebSocket>, filter: &Filter) -> BaseFilter<WebSocket, Log> {
+    loop {
+        match web3.eth_filter().create_logs_filter(filter.clone()).await {
+            Err(e) => println!("get filter failed: {}", e),
+            Ok(filter) => return filter,
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}

--- a/examples/readme.md
+++ b/examples/readme.md
@@ -1,6 +1,6 @@
 First, run ganache
 
-    ganache-cli -b 3 -m "hamster coin cup brief quote trick stove draft hobby strong caught unable"
+    ganache-cli -b 3 -m "hamster coin cup brief quote trick stove draft hobby strong caught unable" --db ./db
 
 Using this mnemonic makes the static account addresses in the example line up
 

--- a/examples/transport_ws_loss_connection.rs
+++ b/examples/transport_ws_loss_connection.rs
@@ -1,0 +1,28 @@
+use std::time::Duration;
+
+use ethabi::Address;
+use web3::{api::Eth, transports::WebSocket};
+
+#[tokio::main]
+async fn main() -> web3::Result<()> {
+    let _ = env_logger::try_init();
+    let transport = web3::transports::WebSocket::new("ws://localhost:8545").await?;
+    let web3 = web3::Web3::new(transport);
+
+    println!("Calling accounts.");
+    let accounts = web3.eth().accounts().await?;
+
+    interval_balance(&web3.eth(), accounts[0]).await;
+
+    Ok(())
+}
+
+async fn interval_balance(eth: &Eth<WebSocket>, account: Address) {
+    loop {
+        match eth.balance(account, None).await {
+            Ok(balance) => println!("Balance of {:?}: {}", account, balance),
+            Err(e) => println!("Get balance failed: {}", e),
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+}

--- a/src/api/eth_subscribe.rs
+++ b/src/api/eth_subscribe.rs
@@ -52,7 +52,7 @@ pub struct SubscriptionStream<T: DuplexTransport, I> {
     id: SubscriptionId,
     #[pin]
     rx: T::NotificationStream,
-    _marker: PhantomData<I>,
+    _marker: PhantomData<error::Result<I>>,
 }
 
 impl<T: DuplexTransport, I> SubscriptionStream<T, I> {
@@ -90,7 +90,7 @@ where
     fn poll_next(self: Pin<&mut Self>, ctx: &mut Context) -> Poll<Option<Self::Item>> {
         let this = self.project();
         let x = ready!(this.rx.poll_next(ctx));
-        Poll::Ready(x.map(|result| serde_json::from_value(result).map_err(Into::into)))
+        Poll::Ready(x.map(|result| result.and_then(|v| serde_json::from_value(v).map_err(Into::into))))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ pub trait BatchTransport: Transport {
 /// A transport implementation supporting pub sub subscriptions.
 pub trait DuplexTransport: Transport {
     /// The type of stream this transport returns
-    type NotificationStream: futures::Stream<Item = rpc::Value>;
+    type NotificationStream: futures::Stream<Item = error::Result<rpc::Value>>;
 
     /// Add a subscription to this transport
     fn subscribe(&self, id: api::SubscriptionId) -> error::Result<Self::NotificationStream>;

--- a/src/transports/either.rs
+++ b/src/transports/either.rs
@@ -72,10 +72,10 @@ where
     B: DuplexTransport<NotificationStream = BStream>,
     A::Out: 'static + Send,
     B::Out: 'static + Send,
-    AStream: futures::Stream<Item = rpc::Value> + 'static + Send,
-    BStream: futures::Stream<Item = rpc::Value> + 'static + Send,
+    AStream: futures::Stream<Item = error::Result<rpc::Value>> + 'static + Send,
+    BStream: futures::Stream<Item = error::Result<rpc::Value>> + 'static + Send,
 {
-    type NotificationStream = BoxStream<'static, rpc::Value>;
+    type NotificationStream = BoxStream<'static, error::Result<rpc::Value>>;
 
     fn subscribe(&self, id: api::SubscriptionId) -> error::Result<Self::NotificationStream> {
         Ok(match *self {


### PR DESCRIPTION
https://github.com/tomusdrw/rust-web3/issues/627

Firstly, run ganache `ganache-cli -b 3 -m "hamster coin cup brief quote trick stove draft hobby strong caught unable" --db ./db`

* Test for request
run example `cargo run --package web3 --example transport_ws_loss_connection`.
Got logs
```
Calling accounts.
Balance of 0xd028d24f16a8893bd078259d413372ac01580769: 99993030720000000000
Balance of 0xd028d24f16a8893bd078259d413372ac01580769: 99993030720000000000
```
Then restart ganache, got logs:
```
Get balance failed: Cannot send request. Internal task finished.
Get balance failed: Cannot send request. Internal task finished.
Get balance failed: Cannot send request. Internal task finished.
Balance of 0xd028d24f16a8893bd078259d413372ac01580769: 99993030720000000000
Balance of 0xd028d24f16a8893bd078259d413372ac01580769: 99993030720000000000
Balance of 0xd028d24f16a8893bd078259d413372ac01580769: 99993030720000000000
```

* Test for subscription
run example `cargo run --package web3 --example contract_log_filter_loss_connection`
Got logs:
```
Calling accounts.
contract deployed at: 0xfc62…37fa
got tx: 0xbff1b99fd6615750ead80c19d980191910d86cd5635a86a4a259678cc64f94f8
got tx: 0x056e56e3978879d3d72b7c0e0638e6f1d5cdffc2034897eeb5aa6e5fcd2a8f41
Get log: Log { address: 0xfc62729d4553ddde1ad33eca00b28ac2aef937fa, topics: [0xd282f389399565f3671145f5916e51652b60eee8e5c759293a2f5771b8ddfd2e], data: Bytes([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 208, 40, 210, 79, 22, 168, 137, 59, 208, 120, 37, 157, 65, 51, 114, 172, 1, 88, 7, 105]), block_hash: Some(0x8c2e6059e681ca65faf4b0d2eebbac836c36dcbec6c1c850dc57241138d7362d), block_number: Some(44), transaction_hash: Some(0xbff1b99fd6615750ead80c19d980191910d86cd5635a86a4a259678cc64f94f8), transaction_index: Some(0), log_index: Some(0), transaction_log_index: None, log_type: None, removed: Some(false) }
got tx: 0xcfa5b4c8bc4bf4448e73fb2d7efd4dda5150286146fd2564bb72f976a20e4acb
got tx: 0xc3c3c98760e01143633fc4a5bb4800570cf6358b1ebc0eccc2ffef2643452f66
Get log: Log { address: 0xfc62729d4553ddde1ad33eca00b28ac2aef937fa, topics: [0xd282f389399565f3671145f5916e51652b60eee8e5c759293a2f5771b8ddfd2e], data: Bytes([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 208, 40, 210, 79, 22, 168, 137, 59, 208, 120, 37, 157, 65, 51, 114, 172, 1, 88, 7, 105]), block_hash: Some(0x6f70e5987191d222c6fb056147ce3d9e4e8a6dcb8857a14cb8c3f4c5610ed909), block_number: Some(45), transaction_hash: Some(0x056e56e3978879d3d72b7c0e0638e6f1d5cdffc2034897eeb5aa6e5fcd2a8f41), transaction_index: Some(0), log_index: Some(0), transaction_log_index: None, log_type: None, removed: Some(false) }
```
Then restarted ganache, got logs:
```
Log Filter Error: WS connection error: Closed
get tx failed: Api error: Cannot send request. Internal task finished.
get filter failed: Cannot send request. Internal task finished.
get tx failed: Api error: Cannot send request. Internal task finished.
get filter failed: Cannot send request. Internal task finished.
get tx failed: Api error: Cannot send request. Internal task finished.
got tx: 0xeef5ee71c5ed18861cd02763e41ff5a502a8c883e1ad6f754222563763f0b831
got tx: 0x8273a2e8e49b265467a3574420a742e03611049f73f212bc8d588cac72e852c8
Get log: Log { address: 0xfc62729d4553ddde1ad33eca00b28ac2aef937fa, topics: [0xd282f389399565f3671145f5916e51652b60eee8e5c759293a2f5771b8ddfd2e], data: Bytes([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 208, 40, 210, 79, 22, 168, 137, 59, 208, 120, 37, 157, 65, 51, 114, 172, 1, 88, 7, 105]), block_hash: Some(0x98b799d67d909361a9face5e4a917b3b214dce5ecedf1790b76dae75661d4bf4), block_number: Some(46), transaction_hash: Some(0xeef5ee71c5ed18861cd02763e41ff5a502a8c883e1ad6f754222563763f0b831), transaction_index: Some(0), log_index: Some(0), transaction_log_index: None, log_type: None, removed: Some(false) }
Get log: Log { address: 0xfc62729d4553ddde1ad33eca00b28ac2aef937fa, topics: [0xd282f389399565f3671145f5916e51652b60eee8e5c759293a2f5771b8ddfd2e], data: Bytes([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 208, 40, 210, 79, 22, 168, 137, 59, 208, 120, 37, 157, 65, 51, 114, 172, 1, 88, 7, 105]), block_hash: Some(0x98b799d67d909361a9face5e4a917b3b214dce5ecedf1790b76dae75661d4bf4), block_number: Some(46), transaction_hash: Some(0x8273a2e8e49b265467a3574420a742e03611049f73f212bc8d588cac72e852c8), transaction_index: Some(1), log_index: Some(0), transaction_log_index: None, log_type: None, removed: Some(false) }
```