### PR TITLE
Make Transaction from account signing public

### DIFF
--- a/src/api/accounts.rs
+++ b/src/api/accounts.rs
@@ -36,7 +36,7 @@ impl<T: Transport> Accounts<T> {
 }
 
 #[cfg(feature = "signing")]
-mod accounts_signing {
+pub(crate) mod accounts_signing {
     use super::*;
     use crate::{
         api::Web3,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -28,6 +28,9 @@ pub use self::{
     web3::Web3 as Web3Api,
 };
 
+#[cfg(feature = "signing")]
+pub use self::accounts::accounts_signing::Transaction;
+
 use crate::{
     confirm, error,
     types::{Bytes, TransactionReceipt, TransactionRequest, U64},


### PR DESCRIPTION
# Problem
It's impossible to use web3 library for signing transactions without using any transport.

# Description  
In our project, we use the signer regardless of the transport and fill all necessary fields by our logic. We do not need to go to the transport to get nonce and gas price. But we want to use `Transaction` for signing because rlp encoding/decoding is not trivial and it's easy to make a mistake here.

# Solution 
 I made the necessary struct public it allows us to use just a private key for the signing structure, where all necessary fields are filled.
