### PR TITLE
Re-export secp256k1::SecretKey.

### DIFF
--- a/examples/transaction_public.rs
+++ b/examples/transaction_public.rs
@@ -1,10 +1,9 @@
 use std::str::FromStr;
 
-use secp256k1::SecretKey;
-
 use web3::{
     ethabi::ethereum_types::U256,
     types::{Address, TransactionParameters},
+    signing::SecretKey,
 };
 
 /// Below generates and signs a transaction offline, before transmitting it to a public node (eg Infura)

--- a/examples/transaction_public.rs
+++ b/examples/transaction_public.rs
@@ -2,8 +2,8 @@ use std::str::FromStr;
 
 use web3::{
     ethabi::ethereum_types::U256,
-    types::{Address, TransactionParameters},
     signing::SecretKey,
+    types::{Address, TransactionParameters},
 };
 
 /// Below generates and signs a transaction offline, before transmitting it to a public node (eg Infura)

--- a/src/signing.rs
+++ b/src/signing.rs
@@ -31,7 +31,7 @@ mod feature_gated {
     use super::*;
     use crate::types::Address;
     use once_cell::sync::Lazy;
-    pub(crate) use secp256k1::SecretKey;
+    pub use secp256k1::SecretKey;
     use secp256k1::{
         ecdsa::{RecoverableSignature, RecoveryId},
         All, Message, PublicKey, Secp256k1,


### PR DESCRIPTION
`secp256k1::SecretKey` is required in order to use the offline signing functionality but at present it's not re-exported. This means anyone who want to use the signing functionality has to add an explicit dependency on `secp256k1`, and has to keep it in-sync with the version in `web3`.

This PR changes the re-export of the `secp256k1::SecretKey` from `pub(crate)` to `pub` so that is can be accessed through the `web3::signing` module, removing the requirement for an explicit dependency on secp256k1.