### PR TITLE
Document the cloning behavior for Batch

### DIFF
--- a/src/transports/batch.rs
+++ b/src/transports/batch.rs
@@ -16,6 +16,9 @@ type Pending = oneshot::Sender<error::Result<rpc::Value>>;
 type PendingRequests = Arc<Mutex<BTreeMap<RequestId, Pending>>>;
 
 /// Transport allowing to batch queries together.
+///
+/// Note: cloned instances of [Batch] share the queues of pending and unsent requests.
+/// If you want to avoid it, use [Batch::new] repeatedly instead.
 #[derive(Debug, Clone)]
 pub struct Batch<T> {
     transport: T,


### PR DESCRIPTION
We could consider adding something like 

```
impl<T: BatchTransport> Batch<T> {
    pub fn deep_clone(&self) -> Self {
        Self::new(self.transport.clone())
    }
}
```
or perhaps this is what we'd like to use for `Clone`, actually?