### PR TITLE
Add the wallet_switchEthereumChain method to the eip1193 transport

### DIFF
--- a/src/transports/eip_1193.rs
+++ b/src/transports/eip_1193.rs
@@ -132,6 +132,24 @@ impl Eip1193 {
             .into_deserializer();
         O::deserialize(deserializer).expect(&format!("couldn't deserialize {}", name))
     }
+
+    /// EIP-3326: Switch a wallet to another chain
+    pub async fn switch_chain(&self, chain_id: &str) -> Result<serde_json::value::Value, error::Error> {
+        let js_params = JsValue::from_serde(&vec![&ChainId { chain_id: chain_id.to_string() }])
+            .expect("couldn't send method params via JSON");
+
+        self.provider_and_listeners.borrow().provider.request_wrapped(RequestArguments {
+            method: String::from("wallet_switchEthereumChain"),
+            params: js_sys::Array::from(&js_params),
+        })
+        .await
+    }
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChainId {
+    pub chain_id: String,
 }
 
 /// Event data sent from the JavaScript side to our callback.


### PR DESCRIPTION
This adds support for [eip3326](https://eips.ethereum.org/EIPS/eip-3326), calling `wallet_switchEthereumChain`. It will allow a dapp to request a chain switch for a user with a eip1193 transport (such as metamask).

There are other methods that go alongside this method, but I'm not sure if this is the canonical way to implement this into `rust-web3`, so I only implemented the smallest (simplest) method first.

To test this, you'd want to have a transport from your provider like this:
```rust
        let transport = Eip1193::new(self.provider.clone());
        transport.switch_chain(chain_id)
```

I'm not sure if the return values are ideomatic to your api either. Any guidance would be helpful as these functions are critical for any user wishing to develop web3 dapps in rust with a eip1193 transport.