### PR TITLE
fix: re-export rpc::Call

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub mod signing;
 pub mod transports;
 pub mod types;
 
+pub use rpc::Call;
 pub use crate::{
     api::Web3,
     error::{Error, Result},


### PR DESCRIPTION
This type is used in the public API of the crate. Re-exporting seems like a good idea.