### PR TITLE
Replace `JsValue::into/from_serde` with `serde-wasm-bindgen`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,9 +51,10 @@ url = { version = "2.1", optional = true }
 ## EIP-1193
 js-sys = { version = "0.3.45", optional = true }
 ### This is a transitive dependency, only here so we can turn on its wasm_bindgen feature
-rand = { version = "0.8.1", optional = true }
 getrandom = { version = "0.2", features = ["js"], optional = true }
-wasm-bindgen = { version = "0.2.68", optional = true, features = ["serde-serialize"] }
+rand = { version = "0.8.1", optional = true }
+serde-wasm-bindgen = { version = "0.4.3", optional = true }
+wasm-bindgen = { version = "0.2.68", optional = true }
 wasm-bindgen-futures = { version = "0.4.18", optional = true }
 
 [dev-dependencies]
@@ -69,7 +70,7 @@ tokio-stream = { version = "0.1", features = ["net"] }
 
 [features]
 default = ["http-tls", "signing", "ws-tls-tokio", "ipc-tokio"]
-wasm = ["js-sys", "wasm-bindgen", "wasm-bindgen-futures", "futures-timer/wasm-bindgen", "rand", "getrandom"]
+wasm = ["futures-timer/wasm-bindgen", "getrandom", "js-sys", "rand", "serde-wasm-bindgen", "wasm-bindgen", "wasm-bindgen-futures"]
 eip-1193 = ["wasm"]
 _http_base = ["reqwest", "bytes", "url", "base64", "headers"]
 http = ["_http_base"]

--- a/src/transports/eip_1193.rs
+++ b/src/transports/eip_1193.rs
@@ -239,7 +239,6 @@ impl Provider {
     fn parse_response(resp: Result<JsValue, JsValue>) -> error::Result<serde_json::value::Value> {
         // Fix #544
         #[derive(Debug, Deserialize)]
-        #[serde(deny_unknown_fields)]
         pub struct RPCErrorExtra {
             /// Code
             pub code: RPCErrorCode,
@@ -373,10 +372,6 @@ mod tests {
     fn returns_error_on_invalid_response() {
         assert!(matches!(
             Provider::parse_response(Err(json_to_js(r#"{"code": "red", "message": ""}"#))),
-            Err(Error::InvalidResponse(_))
-        ));
-        assert!(matches!(
-            Provider::parse_response(Err(json_to_js(r#"{"code": 0, "message": "", "extra": true}"#))),
             Err(Error::InvalidResponse(_))
         ));
         assert!(matches!(


### PR DESCRIPTION
`wasm-bindgen::serde-serialize` feature may lead to a cyclic package dependency like
```
error: cyclic package dependency: package `wasm-bindgen v0.2.74` depends on itself. Cycle:
package `wasm-bindgen v0.2.74`
    ... which is depended on by `js-sys v0.3.51`
    ... which is depended on by `getrandom v0.2.2`
    ... which is depended on by `ahash v0.7.4`
    ... which is depended on by `hashbrown v0.11.2`
    ... which is depended on by `indexmap v1.7.0`
    ... which is depended on by `serde_json v1.0.57`
    ... which is depended on by `wasm-bindgen v0.2.74`
    ... which is depended on by `getrandom v0.1.14`
    ... which is depended on by `const-random-macro v0.1.8`
    ... which is depended on by `const-random v0.1.8`
    ... which is depended on by `ahash v0.2.18`
```

Due to this problem, `JsValue::into_serde` and `JsValue::from_serde` were deprecated at https://github.com/rustwasm/wasm-bindgen/pull/3031

Motivation: https://github.com/KomodoPlatform/atomicDEX-API/issues/1042#issuecomment-1348375886