### PR TITLE
feat: adds finalized and safe block types

### DIFF
--- a/src/types/block.rs
+++ b/src/types/block.rs
@@ -128,6 +128,10 @@ where
 /// Block Number
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum BlockNumber {
+    /// Finalized block
+    Finalized,
+    /// Safe block
+    Safe,
     /// Latest block
     Latest,
     /// Earliest block (genesis)
@@ -154,6 +158,8 @@ impl Serialize for BlockNumber {
             BlockNumber::Latest => serializer.serialize_str("latest"),
             BlockNumber::Earliest => serializer.serialize_str("earliest"),
             BlockNumber::Pending => serializer.serialize_str("pending"),
+            BlockNumber::Finalized => serializer.serialize_str("finalized"),
+            BlockNumber::Safe => serializer.serialize_str("safe"),
         }
     }
 }
@@ -168,6 +174,8 @@ impl<'a> Deserialize<'a> for BlockNumber {
             "latest" => Ok(BlockNumber::Latest),
             "earliest" => Ok(BlockNumber::Earliest),
             "pending" => Ok(BlockNumber::Pending),
+            "finalized" => Ok(BlockNumber::Finalized),
+            "safe" => Ok(BlockNumber::Safe),
             _ if value.starts_with("0x") => U64::from_str_radix(&value[2..], 16)
                 .map(BlockNumber::Number)
                 .map_err(|e| D::Error::custom(format!("invalid block number: {}", e))),
@@ -329,6 +337,18 @@ mod tests {
         assert_eq!(serialized, "pending");
         let deserialized = serde_json::from_value::<BlockNumber>(serialized).unwrap();
         assert_eq!(deserialized, BlockNumber::Pending);
+
+        // BlockNumber::Finalized
+        let serialized = serde_json::to_value(BlockNumber::Finalized).unwrap();
+        assert_eq!(serialized, "finalized");
+        let deserialized = serde_json::from_value::<BlockNumber>(serialized).unwrap();
+        assert_eq!(deserialized, BlockNumber::Finalized);
+
+        // BlockNumber::Safe
+        let serialized = serde_json::to_value(BlockNumber::Safe).unwrap();
+        assert_eq!(serialized, "safe");
+        let deserialized = serde_json::from_value::<BlockNumber>(serialized).unwrap();
+        assert_eq!(deserialized, BlockNumber::Safe);
 
         // BlockNumber::Number
         let serialized = serde_json::to_value(BlockNumber::Number(100.into())).unwrap();


### PR DESCRIPTION
Adds two new `BlockNumber`'s variants: `Safe` and `Finalized` to be up to date with the latest RPC calls. Fixes #684 