### PR TITLE
test(types): add test should_deserialize_receipt_with_logs

### DIFF
--- a/src/transports/http.rs
+++ b/src/transports/http.rs
@@ -230,17 +230,18 @@ mod tests {
         use hyper::service::{make_service_fn, service_fn};
 
         // given
-        let addr = format!("127.0.0.1:{}", get_available_port().unwrap()).as_str();
+        let addr = format!("127.0.0.1:{}", get_available_port().unwrap());
         // start server
         let service = make_service_fn(|_| async { Ok::<_, hyper::Error>(service_fn(server)) });
         let server = hyper::Server::bind(&addr.parse().unwrap()).serve(service);
+        let addr_clone = addr.clone();
         tokio::spawn(async move {
-            println!("Listening on http://{}", addr);
+            println!("Listening on http://{}", addr_clone);
             server.await.unwrap();
         });
 
         // when
-        let client = Http::new(&format!("http://{}", addr)).unwrap();
+        let client = Http::new(&format!("http://{}", &addr)).unwrap();
         println!("Sending request");
         let response = client.execute("eth_getAccounts", vec![]).await;
         println!("Got response");
@@ -266,17 +267,18 @@ mod tests {
         }
 
         // given
-        let addr = format!("127.0.0.1:{}", get_available_port().unwrap()).as_str();
+        let addr = format!("127.0.0.1:{}", get_available_port().unwrap());
         // start server
         let service = make_service_fn(|_| async { Ok::<_, hyper::Error>(service_fn(handler)) });
         let server = hyper::Server::bind(&addr.parse().unwrap()).serve(service);
+        let addr_clone = addr.clone();
         tokio::spawn(async move {
-            println!("Listening on http://{}", addr);
+            println!("Listening on http://{}", addr_clone);
             server.await.unwrap();
         });
 
         // when
-        let client = Http::new(&format!("http://{}", addr)).unwrap();
+        let client = Http::new(&format!("http://{}", &addr)).unwrap();
         println!("Sending request");
         let response = client
             .send_batch(vec![client.prepare("some_method", vec![])].into_iter())

--- a/src/transports/http.rs
+++ b/src/transports/http.rs
@@ -230,7 +230,7 @@ mod tests {
         use hyper::service::{make_service_fn, service_fn};
 
         // given
-        let addr = format!("127.0.0.1:{}", get_available_port().unwrap());
+        let addr = format!("127.0.0.1:{}", get_available_port().unwrap()).as_str();
         // start server
         let service = make_service_fn(|_| async { Ok::<_, hyper::Error>(service_fn(server)) });
         let server = hyper::Server::bind(&addr.parse().unwrap()).serve(service);
@@ -266,7 +266,7 @@ mod tests {
         }
 
         // given
-        let addr = format!("127.0.0.1:{}", get_available_port().unwrap());
+        let addr = format!("127.0.0.1:{}", get_available_port().unwrap()).as_str();
         // start server
         let service = make_service_fn(|_| async { Ok::<_, hyper::Error>(service_fn(handler)) });
         let server = hyper::Server::bind(&addr.parse().unwrap()).serve(service);

--- a/src/transports/http.rs
+++ b/src/transports/http.rs
@@ -194,6 +194,18 @@ mod tests {
     use super::*;
     use crate::Error::Rpc;
     use jsonrpc_core::ErrorCode;
+    use std::net::TcpListener;
+
+    fn port_is_available(port: u16) -> bool {
+        match TcpListener::bind(("127.0.0.1", port)) {
+            Ok(_) => true,
+            Err(_) => false,
+        }
+    }
+
+    fn get_available_port() -> Option<u16> {
+        (3001..65535).find(|port| port_is_available(*port))
+    }
 
     async fn server(req: hyper::Request<hyper::Body>) -> hyper::Result<hyper::Response<hyper::Body>> {
         use hyper::body::HttpBody;
@@ -218,7 +230,7 @@ mod tests {
         use hyper::service::{make_service_fn, service_fn};
 
         // given
-        let addr = "127.0.0.1:3001";
+        let addr = format!("127.0.0.1:{}", get_available_port());
         // start server
         let service = make_service_fn(|_| async { Ok::<_, hyper::Error>(service_fn(server)) });
         let server = hyper::Server::bind(&addr.parse().unwrap()).serve(service);
@@ -254,7 +266,7 @@ mod tests {
         }
 
         // given
-        let addr = "127.0.0.1:3001";
+        let addr = format!("127.0.0.1:{}", get_available_port());
         // start server
         let service = make_service_fn(|_| async { Ok::<_, hyper::Error>(service_fn(handler)) });
         let server = hyper::Server::bind(&addr.parse().unwrap()).serve(service);

--- a/src/transports/http.rs
+++ b/src/transports/http.rs
@@ -230,7 +230,7 @@ mod tests {
         use hyper::service::{make_service_fn, service_fn};
 
         // given
-        let addr = format!("127.0.0.1:{}", get_available_port());
+        let addr = format!("127.0.0.1:{}", get_available_port().unwrap());
         // start server
         let service = make_service_fn(|_| async { Ok::<_, hyper::Error>(service_fn(server)) });
         let server = hyper::Server::bind(&addr.parse().unwrap()).serve(service);
@@ -266,7 +266,7 @@ mod tests {
         }
 
         // given
-        let addr = format!("127.0.0.1:{}", get_available_port());
+        let addr = format!("127.0.0.1:{}", get_available_port().unwrap());
         // start server
         let service = make_service_fn(|_| async { Ok::<_, hyper::Error>(service_fn(handler)) });
         let server = hyper::Server::bind(&addr.parse().unwrap()).serve(service);

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -230,6 +230,42 @@ mod tests {
     }
 
     #[test]
+    fn should_deserialize_receipt_with_logs() {
+        let receipt_str = r#"{
+        "blockHash": "0x83eaba432089a0bfe99e9fc9022d1cfcb78f95f407821be81737c84ae0b439c5",
+        "blockNumber": "0x38",
+        "contractAddress": "0x03d8c4566478a6e1bf75650248accce16a98509f",
+        "from": "0x407d73d8a49eeb85d32cf465507dd71d507100c1",
+        "to": "0x853f43d8a49eeb85d32cf465507dd71d507100c1",
+        "cumulativeGasUsed": "0x927c0",
+        "gasUsed": "0x927c0",
+        "logs": [
+            {
+                "address": "0x03d8c4566478a6e1bf75650248accce16a98509f",
+                "topics": [
+                ],
+                "data": "0x03d8c4566478a6e1bf75650248accce16a98509f",
+                "blockNumber": "0x38",
+                "transactionHash": "0x422fb0d5953c0c48cbb42fb58e1c30f5e150441c68374d70ca7d4f191fd56f26",
+                "transactionIndex": "0x0",
+                "blockHash": "0x83eaba432089a0bfe99e9fc9022d1cfcb78f95f407821be81737c84ae0b439c5",
+                "logIndex": "0x0",
+                "removed": false
+            }
+        ],
+        "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "root": null,
+        "transactionHash": "0x422fb0d5953c0c48cbb42fb58e1c30f5e150441c68374d70ca7d4f191fd56f26",
+        "transactionIndex": "0x0",
+        "status": "0x1",
+        "effectiveGasPrice": "0x100"
+    }"#;
+
+        let receipt: Receipt = serde_json::from_str(receipt_str).unwrap();
+        assert_eq!(receipt.logs.len(), 1);
+    }
+
+    #[test]
     fn test_deserialize_signed_tx_parity() {
         // taken from RPC docs.
         let tx_str = r#"{


### PR DESCRIPTION
Add a log deserialization test.
Added support for dynamic listening ports to avoid occasional failures during concurrent tests