### PR TITLE
feat(transports): add retries to HTTP transport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ serde = { version = "1.0.90", features = ["derive"] }
 serde_json = "1.0.39"
 tiny-keccak = { version = "2.0.1", features = ["keccak"] }
 pin-project = "1.0"
-async-recursion = "1.0.5"
 chrono = "0.4.31"
 # Optional deps
 secp256k1 = { version = "0.28", features = ["recovery"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,15 +77,7 @@ tokio-stream = { version = "0.1", features = ["net"] }
 
 [features]
 default = ["http-tls", "signing", "ws-tls-tokio", "ipc-tokio"]
-wasm = [
-    "futures-timer/wasm-bindgen",
-    "getrandom",
-    "js-sys",
-    "rand",
-    "serde-wasm-bindgen",
-    "wasm-bindgen",
-    "wasm-bindgen-futures",
-]
+wasm = ["futures-timer/wasm-bindgen", "getrandom", "js-sys", "rand", "serde-wasm-bindgen", "wasm-bindgen", "wasm-bindgen-futures"]
 eip-1193 = ["wasm"]
 _http_base = ["reqwest", "bytes", "url", "base64"]
 http = ["_http_base"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ serde = { version = "1.0.90", features = ["derive"] }
 serde_json = "1.0.39"
 tiny-keccak = { version = "2.0.1", features = ["keccak"] }
 pin-project = "1.0"
+async-recursion = "1.0.5"
+chrono = "0.4.31"
 # Optional deps
 secp256k1 = { version = "0.28", features = ["recovery"], optional = true }
 once_cell = { version = "1.8.0", optional = true }
@@ -75,7 +77,15 @@ tokio-stream = { version = "0.1", features = ["net"] }
 
 [features]
 default = ["http-tls", "signing", "ws-tls-tokio", "ipc-tokio"]
-wasm = ["futures-timer/wasm-bindgen", "getrandom", "js-sys", "rand", "serde-wasm-bindgen", "wasm-bindgen", "wasm-bindgen-futures"]
+wasm = [
+    "futures-timer/wasm-bindgen",
+    "getrandom",
+    "js-sys",
+    "rand",
+    "serde-wasm-bindgen",
+    "wasm-bindgen",
+    "wasm-bindgen-futures",
+]
 eip-1193 = ["wasm"]
 _http_base = ["reqwest", "bytes", "url", "base64"]
 http = ["_http_base"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,20 @@ pub enum TransportError {
     /// Arbitrary, developer-readable description of the occurred error.
     #[display(fmt = "{}", _0)]
     Message(String),
+    /// Recoverable rate limit error.
+    #[display(fmt = "rate limit: {}", _0)]
+    RateLimit(RateLimit),
+}
+
+/// Recoverable rate limit error.
+#[derive(Display, Debug, Clone, PartialEq)]
+pub enum RateLimit {
+    /// Retry-After: <http-date>
+    #[display(fmt = "retry after date {}", _0)]
+    Date(String),
+    /// Retry-After: <delay-seconds>
+    #[display(fmt = "retry after number of seconds {}", _0)]
+    Seconds(u64),
 }
 
 /// Errors which can occur when attempting to generate resource uri.

--- a/src/transports/http.rs
+++ b/src/transports/http.rs
@@ -1,8 +1,7 @@
 //! HTTP Transport
 
-use crate::error::RateLimit;
 use crate::{
-    error::{Error, Result, TransportError},
+    error::{Error, RateLimit, Result, TransportError},
     helpers, BatchTransport, RequestId, Transport,
 };
 use async_recursion::async_recursion;
@@ -14,8 +13,7 @@ use futures::future::BoxFuture;
 use futures::future::LocalBoxFuture as BoxFuture;
 use futures_timer::Delay;
 use jsonrpc_core::types::{Call, Output, Request, Value};
-use reqwest::header::HeaderMap;
-use reqwest::{Client, Url};
+use reqwest::{header::HeaderMap, Client, Url};
 use serde::de::DeserializeOwned;
 use std::{
     collections::HashMap,
@@ -310,15 +308,15 @@ mod tests {
     use super::*;
     use crate::Error::Rpc;
     use core::pin::Pin;
-    use futures::lock::Mutex;
-    use futures::Future;
-    use hyper::body::HttpBody;
-    use hyper::service::{make_service_fn, service_fn};
-    use hyper::{Body, Error, Method, Request, Response, Server};
+    use futures::{lock::Mutex, Future};
+    use hyper::{
+        body::HttpBody,
+        service::{make_service_fn, service_fn},
+        Body, Error, Method, Request, Response, Server,
+    };
     use jsonrpc_core::ErrorCode;
     use std::net::TcpListener;
-    use tokio::task::JoinHandle;
-    use tokio::time::Instant;
+    use tokio::{task::JoinHandle, time::Instant};
 
     type HyperResponse = Pin<Box<dyn Future<Output = hyper::Result<Response<Body>>> + Send>>;
 


### PR DESCRIPTION
Changes:

- added retries on 429 status code (that use value from `Retry-After` header)
- added retries on 429|500+ status codes (that use exponential backoff)
- unified tests and added tests for new functionality

Reasoning:

- in my application I execute requests in parallel, which leads to lots of 429s due to rate limiting. My PR enables automatic retries on rate limits (429) and server errors (500+) for HTTP transport

I'm looking for feedback. Current implementation is simple and straightforward, but it is able to solve problems that I encountered. I can try to implement similar mechanism for WS transport if this PR gets approved and merged.