### PR TITLE
Fix ws close

### DIFF
--- a/src/transports/ws.rs
+++ b/src/transports/ws.rs
@@ -236,7 +236,9 @@ impl WsServerTask {
                             log::warn!("Unsubscribing from non-existent subscription with id {:?}", id);
                         }
                     }
-                    None => {}
+                    None => {
+                        sender.close().await.expect("Fail to close WS")
+                    }
                 },
                 res = receiver.next() => match res {
                     Some(Ok(data)) => {


### PR DESCRIPTION
@tomusdrw not sure if this is the right place to fix it, but it work for my web server.

Basically, the problem I faced is the WS transport, will only open connections, but do not close them. This may result in too many open files, if the code is inside a closure.