### PR TITLE
FilterBuilder::topics documentation 

### DIFF
--- a/src/types/log.rs
+++ b/src/types/log.rs
@@ -137,6 +137,14 @@ impl FilterBuilder {
     }
 
     /// Topics
+    /// An event topic is a part of the event logging mechanism used by smart contracts
+    /// to record information on the blockchain.
+    /// These logs are stored in transaction receipts and can be efficiently filtered and searched.
+    /// Each log entry has -up to- four "topics," which are 32-byte values used to index the log.
+    ///    Topic 0: The hash of the event signature.
+    ///    Topic 1: The from address (indexed).
+    ///    Topic 2: The to address (indexed).
+    ///    Data: The value (not indexed).
     pub fn topics(
         mut self,
         topic1: Option<Vec<H256>>,


### PR DESCRIPTION
## Overview

Add explanatory documentation to the FilterBuilder::topics method, as it takes up to 4 arguments. To make it easy for the users to know how to use it and what to expect.